### PR TITLE
Setup project structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 help:
 	@echo "make setup-dev         Setup local dev environment"
+	@echo "--"
+	@echo "make test              Run all tests"
 
 setup-dev:
 	psql -d template1 -tc "SELECT 1 FROM pg_database WHERE datname = 'configsum_dev'" | grep -q 1 || psql -d template1 -c "CREATE DATABASE configsum_dev"
 	psql -d template1 -tc "SELECT 1 FROM pg_database WHERE datname = 'configsum_test'" | grep -q 1 || psql -d template1 -c "CREATE DATABASE configsum_test"
+
+test: test-integration
+
+test-integration:
+	go test -tags integration ./...

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+help:
+	@echo "make setup-dev         Setup local dev environment"
+
+setup-dev:
+	psql -d template1 -tc "SELECT 1 FROM pg_database WHERE datname = 'configsum_dev'" | grep -q 1 || psql -d template1 -c "CREATE DATABASE configsum_dev"
+	psql -d template1 -tc "SELECT 1 FROM pg_database WHERE datname = 'configsum_test'" | grep -q 1 || psql -d template1 -c "CREATE DATABASE configsum_test"

--- a/cmd/configsum/main.go
+++ b/cmd/configsum/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/lifesum/configsum/pkg/config"
+	"github.com/lifesum/configsum/pkg/pg"
 )
 
 // Versions.
@@ -48,8 +49,6 @@ const (
 	defaultTimeoutRead  = 1 * time.Second
 	defaultTimeoutWrite = 1 * time.Second
 )
-
-const fmtPostgresURI = "postgres://%s@127.0.0.1:5432/configsum_dev?connect_timeout=5s&sslmode=disable"
 
 // Buildtime vars.
 var revision = "0000000-dev"
@@ -190,5 +189,5 @@ func init() {
 		panic(err)
 	}
 
-	defaultPostgresURI = fmt.Sprintf(fmtPostgresURI, user.Username)
+	defaultPostgresURI = fmt.Sprintf(pg.DefaultDevURI, user.Username)
 }

--- a/cmd/configsum/main.go
+++ b/cmd/configsum/main.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"flag"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Log fields.
+const (
+	logCaller    = "caller"
+	logDuration  = "duration"
+	logHostname  = "hostname"
+	logJob       = "job"
+	logLifecycle = "lifecycle"
+	logListen    = "listen"
+	logNow       = "now"
+	logRevision  = "revision"
+	logService   = "service"
+	logTask      = "task"
+)
+
+// Lifecycles.
+const (
+	lifecycleAbort = "abort"
+	lifecycleStart = "start"
+)
+
+// Buildtime vars.
+var revision = "0000000-dev"
+
+func main() {
+	var (
+		begin = time.Now()
+
+		debug               = flag.Bool("debug", false, "enable debug logging")
+		instrumentationAddr = flag.String("instrumentation.addir", ":8701", "Listen address for instrumentation")
+		listenAddr          = flag.String("listen.addr", ":8700", "Listen address for HTTP API")
+	)
+	flag.Parse()
+
+	// Setup logging.
+	var logger log.Logger
+	{
+		logLevel := level.AllowInfo()
+		if *debug {
+			logLevel = level.AllowAll()
+		}
+		logger = log.With(
+			log.NewJSONLogger(os.Stdout),
+			logCaller, log.Caller(5),
+			logJob, "configsum",
+			logNow, log.DefaultTimestampUTC,
+			logRevision, revision,
+			logTask, "config",
+		)
+		logger = level.NewFilter(logger, logLevel)
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		abort(logger, err)
+	}
+
+	logger = log.With(logger, logHostname, hostname)
+
+	// Setup instrunentation.
+	go func(logger log.Logger, addr string) {
+		mux := http.NewServeMux()
+
+		registerMetrics(mux)
+		registerProfile(mux)
+
+		logger.Log(
+			logDuration, time.Since(begin).Nanoseconds(),
+			logLifecycle, lifecycleStart,
+			logListen, addr,
+			logService, "instrumentation",
+		)
+
+		abort(logger, http.ListenAndServe(addr, mux))
+	}(logger, *instrumentationAddr)
+
+	srv := &http.Server{
+		Addr:         *listenAddr,
+		Handler:      http.NewServeMux(),
+		ReadTimeout:  1 * time.Second,
+		WriteTimeout: 1 * time.Second,
+	}
+
+	_ = level.Info(logger).Log(
+		logDuration, time.Since(begin).Nanoseconds(),
+		logLifecycle, lifecycleStart,
+		logListen, *listenAddr,
+		logService, "api",
+	)
+
+	abort(logger, srv.ListenAndServe())
+}
+
+func abort(logger log.Logger, err error) {
+	if err != nil {
+		return
+	}
+
+	_ = logger.Log("err", err, logLifecycle, lifecycleAbort)
+	os.Exit(1)
+}
+
+func registerMetrics(mux *http.ServeMux) {
+	mux.Handle("/metrics", promhttp.Handler())
+}
+
+func registerProfile(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.Handle("/debug/pprof/block", pprof.Handler("block"))
+	mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+	mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+}

--- a/cmd/configsum/main.go
+++ b/cmd/configsum/main.go
@@ -123,6 +123,7 @@ func main() {
 	if err != nil {
 		abort(logger, err)
 	}
+	userRepo = config.NewUserRepoLogMiddleware(logger, "postgres")(userRepo)
 
 	// Setup serviceinstrument
 	var (

--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -2,16 +2,29 @@ package config
 
 import (
 	"context"
+	"net/http"
+	"time"
 
 	"github.com/go-kit/kit/endpoint"
 )
 
 type userRequest struct{}
 
+type userResponse struct {
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+func (r userResponse) StatusCode() int {
+	return http.StatusCreated
+}
+
 func userEndpoint(svc ServiceUser) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		err := svc.Get()
+		c, err := svc.Get()
+		if err != nil {
+			return nil, err
+		}
 
-		return nil, err
+		return userResponse{CreatedAt: c.createdAt}, nil
 	}
 }

--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -25,7 +25,7 @@ func userEndpoint(svc ServiceUser) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(userRequest)
 
-		c, err := svc.Get(req.baseConfig)
+		c, err := svc.Get(req.baseConfig, "id123")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+type userRequest struct{}
+
+func userEndpoint(svc ServiceUser) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		err := svc.Get()
+
+		return nil, err
+	}
+}

--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -31,7 +31,7 @@ func userEndpoint(svc ServiceUser) endpoint.Endpoint {
 		}
 
 		return userResponse{
-			BaseConfig: c.baseConfig,
+			BaseConfig: c.baseID,
 			CreatedAt:  c.createdAt,
 		}, nil
 	}

--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -8,10 +8,13 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
-type userRequest struct{}
+type userRequest struct {
+	baseConfig string
+}
 
 type userResponse struct {
-	CreatedAt time.Time `json:"createdAt"`
+	BaseConfig string    `json:"baseConfig"`
+	CreatedAt  time.Time `json:"createdAt"`
 }
 
 func (r userResponse) StatusCode() int {
@@ -20,11 +23,16 @@ func (r userResponse) StatusCode() int {
 
 func userEndpoint(svc ServiceUser) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		c, err := svc.Get()
+		req := request.(userRequest)
+
+		c, err := svc.Get(req.baseConfig)
 		if err != nil {
 			return nil, err
 		}
 
-		return userResponse{CreatedAt: c.createdAt}, nil
+		return userResponse{
+			BaseConfig: c.baseConfig,
+			CreatedAt:  c.createdAt,
+		}, nil
 	}
 }

--- a/pkg/config/error.go
+++ b/pkg/config/error.go
@@ -1,0 +1,10 @@
+package config
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Common errors.
+var (
+	ErrNotFound = errors.New("entity not found")
+)

--- a/pkg/config/error.go
+++ b/pkg/config/error.go
@@ -6,5 +6,6 @@ import (
 
 // Common errors.
 var (
+	ErrExists   = errors.New("entity exists")
 	ErrNotFound = errors.New("entity not found")
 )

--- a/pkg/config/inmem.go
+++ b/pkg/config/inmem.go
@@ -1,6 +1,9 @@
 package config
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type inmemBaseRepo struct{}
 
@@ -28,6 +31,13 @@ func (r *inmemUserRepo) Get(baseID, id string) (UserConfig, error) {
 		userID:    id,
 		createdAt: time.Now(),
 	}, nil
+}
+
+func (r *inmemUserRepo) Put(
+	id, baseID, userID string,
+	render rendered,
+) (UserConfig, error) {
+	return UserConfig{}, fmt.Errorf("inmemUserRepo.Put() not implemented")
 }
 
 func (r *inmemUserRepo) Setup() error {

--- a/pkg/config/inmem.go
+++ b/pkg/config/inmem.go
@@ -25,19 +25,19 @@ func NewInmemUserRepo() (UserRepo, error) {
 	return &inmemUserRepo{}, nil
 }
 
+func (r *inmemUserRepo) Append(
+	id, baseID, userID string,
+	render rendered,
+) (UserConfig, error) {
+	return UserConfig{}, fmt.Errorf("inmemUserRepo.Put() not implemented")
+}
+
 func (r *inmemUserRepo) GetLatest(baseID, id string) (UserConfig, error) {
 	return UserConfig{
 		baseID:    baseID,
 		userID:    id,
 		createdAt: time.Now(),
 	}, nil
-}
-
-func (r *inmemUserRepo) Put(
-	id, baseID, userID string,
-	render rendered,
-) (UserConfig, error) {
-	return UserConfig{}, fmt.Errorf("inmemUserRepo.Put() not implemented")
 }
 
 func (r *inmemUserRepo) Setup() error {

--- a/pkg/config/inmem.go
+++ b/pkg/config/inmem.go
@@ -22,10 +22,18 @@ func NewInmemUserRepo() (UserRepo, error) {
 	return &inmemUserRepo{}, nil
 }
 
-func (r *inmemUserRepo) Get(baseName, id string) (*UserConfig, error) {
-	return &UserConfig{
-		baseConfig: baseName,
-		userID:     id,
-		createdAt:  time.Now(),
+func (r *inmemUserRepo) Get(baseID, id string) (UserConfig, error) {
+	return UserConfig{
+		baseID:    baseID,
+		userID:    id,
+		createdAt: time.Now(),
 	}, nil
+}
+
+func (r *inmemUserRepo) Setup() error {
+	return nil
+}
+
+func (r *inmemUserRepo) Teardown() error {
+	return nil
 }

--- a/pkg/config/inmem.go
+++ b/pkg/config/inmem.go
@@ -25,7 +25,7 @@ func NewInmemUserRepo() (UserRepo, error) {
 	return &inmemUserRepo{}, nil
 }
 
-func (r *inmemUserRepo) Get(baseID, id string) (UserConfig, error) {
+func (r *inmemUserRepo) GetLatest(baseID, id string) (UserConfig, error) {
 	return UserConfig{
 		baseID:    baseID,
 		userID:    id,

--- a/pkg/config/inmem.go
+++ b/pkg/config/inmem.go
@@ -1,0 +1,31 @@
+package config
+
+import "time"
+
+type inmemBaseRepo struct{}
+
+// NewInmemBaseRepo returns an in-memory backed BaseRepo implementation.
+func NewInmemBaseRepo() (BaseRepo, error) {
+	return &inmemBaseRepo{}, nil
+}
+
+func (s *inmemBaseRepo) Get(name string) (*BaseConfig, error) {
+	return &BaseConfig{
+		name: name,
+	}, nil
+}
+
+type inmemUserRepo struct{}
+
+// NewInmemUserRepo returns an in-memory backed UserRepo implementation.
+func NewInmemUserRepo() (UserRepo, error) {
+	return &inmemUserRepo{}, nil
+}
+
+func (r *inmemUserRepo) Get(baseName, id string) (*UserConfig, error) {
+	return &UserConfig{
+		baseConfig: baseName,
+		userID:     id,
+		createdAt:  time.Now(),
+	}, nil
+}

--- a/pkg/config/inmem.go
+++ b/pkg/config/inmem.go
@@ -27,6 +27,7 @@ func NewInmemUserRepo() (UserRepo, error) {
 
 func (r *inmemUserRepo) Append(
 	id, baseID, userID string,
+	ruleIDs []string,
 	render rendered,
 ) (UserConfig, error) {
 	return UserConfig{}, fmt.Errorf("inmemUserRepo.Put() not implemented")

--- a/pkg/config/instrument.go
+++ b/pkg/config/instrument.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"time"
+)
+
+const labelRepoUser = "user"
+
+type countFunc func(store, repo, op string)
+type observeFunc func(store, repo, op string, begin time.Time)
+
+type instrumentUserRepo struct {
+	errCount  countFunc
+	opCount   countFunc
+	opObserve observeFunc
+	next      UserRepo
+	store     string
+}
+
+// NewUserRepoInstrumentMiddleware wraps the next UserRepo Prometheus
+// instrumentation capabilities.
+func NewUserRepoInstrumentMiddleware(
+	errCount countFunc,
+	opCount countFunc,
+	opObserve observeFunc,
+	store string,
+) UserRepoMiddleware {
+	return func(next UserRepo) UserRepo {
+		return &instrumentUserRepo{
+			errCount:  errCount,
+			next:      next,
+			opCount:   opCount,
+			opObserve: opObserve,
+			store:     store,
+		}
+	}
+}
+
+func (r *instrumentUserRepo) Append(
+	id, baseID, userID string,
+	ruleIDs []string,
+	render rendered,
+) (c UserConfig, err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "Append")
+	}(time.Now())
+
+	return r.next.Append(id, baseID, userID, ruleIDs, render)
+}
+
+func (r *instrumentUserRepo) GetLatest(
+	baseID, userID string,
+) (c UserConfig, err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "GetLatest")
+	}(time.Now())
+
+	return r.next.GetLatest(baseID, userID)
+}
+
+func (r *instrumentUserRepo) Setup() (err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "Setup")
+	}(time.Now())
+
+	return r.next.Setup()
+}
+
+func (r *instrumentUserRepo) Teardown() (err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "Teardown")
+	}(time.Now())
+
+	return r.next.Teardown()
+}
+
+func (r *instrumentUserRepo) track(begin time.Time, err error, op string) {
+	if err != nil {
+		r.errCount(r.store, labelRepoUser, op)
+
+		return
+	}
+
+	r.opCount(r.store, labelRepoUser, op)
+	r.opObserve(r.store, labelRepoUser, op, begin)
+}

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -72,6 +72,7 @@ func (r *logUserRepo) GetLatest(baseID, userID string) (c UserConfig, err error)
 		ps := []interface{}{
 			logBaseID, baseID,
 			logDuration, time.Since(begin).Nanoseconds(),
+			logOp, "GetLatest",
 			logUserID, userID,
 		}
 
@@ -89,6 +90,7 @@ func (r *logUserRepo) Setup() (err error) {
 	defer func(begin time.Time) {
 		ps := []interface{}{
 			logDuration, time.Since(begin).Nanoseconds(),
+			logOp, "Setup",
 		}
 
 		if err != nil {
@@ -105,6 +107,7 @@ func (r *logUserRepo) Teardown() (err error) {
 	defer func(begin time.Time) {
 		ps := []interface{}{
 			logDuration, time.Since(begin).Nanoseconds(),
+			logOp, "Teardown",
 		}
 
 		if err != nil {

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"time"
+
+	"github.com/go-kit/kit/log"
+)
+
+// Log fields.
+const (
+	logBaseID   = "baseId"
+	logDuration = "duration"
+	logErr      = "err"
+	logID       = "id"
+	logOp       = "op"
+	logPkg      = "pkg"
+	logRendered = "rendered"
+	logRepo     = "repo"
+	logRuleIDs  = "ruleIds"
+	logStore    = "store"
+	logUserID   = "userId"
+)
+
+type logUserRepo struct {
+	logger log.Logger
+	next   UserRepo
+}
+
+// NewUserRepoLogMiddleware wraps the next UserRepo with logging capabilities.
+func NewUserRepoLogMiddleware(logger log.Logger, store string) UserRepoMiddleware {
+	return func(next UserRepo) UserRepo {
+		return &logUserRepo{
+			logger: log.With(
+				logger,
+				logPkg, "config",
+				logRepo, "user",
+				logStore, store,
+			),
+			next: next,
+		}
+	}
+}
+
+func (r *logUserRepo) Append(
+	id, baseID, userID string,
+	ruleIDs []string,
+	render rendered,
+) (c UserConfig, err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logBaseID, baseID,
+			logDuration, time.Since(begin).Nanoseconds(),
+			logID, id,
+			logOp, "Append",
+			logRendered, render,
+			logRuleIDs, ruleIDs,
+			logUserID, userID,
+		}
+
+		if err != nil {
+			ps = append(ps, logErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.Append(id, baseID, userID, ruleIDs, render)
+}
+
+func (r *logUserRepo) GetLatest(baseID, userID string) (c UserConfig, err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logBaseID, baseID,
+			logDuration, time.Since(begin).Nanoseconds(),
+			logUserID, userID,
+		}
+
+		if err != nil {
+			ps = append(ps, logErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.GetLatest(baseID, userID)
+}
+
+func (r *logUserRepo) Setup() (err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logDuration, time.Since(begin).Nanoseconds(),
+		}
+
+		if err != nil {
+			ps = append(ps, logErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.Setup()
+}
+
+func (r *logUserRepo) Teardown() (err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logDuration, time.Since(begin).Nanoseconds(),
+		}
+
+		if err != nil {
+			ps = append(ps, logErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.Teardown()
+}

--- a/pkg/config/postgres.go
+++ b/pkg/config/postgres.go
@@ -1,9 +1,37 @@
 package config
 
 import (
+	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+
+	"github.com/lifesum/configsum/pkg/pg"
+)
+
+const (
+	pgCreateSchema = `CREATE SCHEMA IF NOT EXISTS config`
+	pgCreateTable  = `
+		CREATE TABLE IF NOT EXISTS config.users(
+			id TEXT NOT NULL PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			base_id TEXT NOT NULL,
+			rule_ids TEXT[],
+			rendered JSONB NOT NULL,
+			created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'utc'),
+			activated_at TIMESTAMP WITHOUT TIME ZONE
+		)`
+	pgDropTable = `DROP TABLE IF EXISTS config.users CASCADE`
+
+	pgSelectUsers = `
+		SELECT
+			id, user_id, base_id, rule_ids, rendered, created_at, activated_at
+		FROM
+			config.users
+		LIMIT
+			:limit`
 )
 
 type pgUserRepo struct {
@@ -17,6 +45,70 @@ func NewPostgresUserRepo(db *sqlx.DB) (UserRepo, error) {
 	}, nil
 }
 
-func (r *pgUserRepo) Get(baseName, id string) (*UserConfig, error) {
-	return nil, fmt.Errorf("pgUserRepo.Get() not implemented")
+func (r *pgUserRepo) Get(baseName, id string) (UserConfig, error) {
+	query, args, err := r.db.BindNamed(pgSelectUsers, map[string]interface{}{
+		"limit": 1,
+	})
+	if err != nil {
+		return UserConfig{}, fmt.Errorf("named query: %s", err)
+	}
+
+	raw := struct {
+		BaseID      string                 `db:"base_id"`
+		ID          string                 `db:"id"`
+		Rendered    map[string]interface{} `db:"rendered"`
+		RuleIDs     []string               `db:"rule_ids"`
+		UserID      string                 `db:"user_id"`
+		CreatedAt   time.Time              `db:"created_at"`
+		ActivatedAt time.Time              `db:"activated_at"`
+	}{}
+
+	err = r.db.Get(&raw, query, args...)
+	if err != nil {
+		if pg.IsRelationNotFound(pg.Wrap(err)) {
+			if err := r.Setup(); err != nil {
+				return UserConfig{}, err
+			}
+
+			return r.Get(baseName, id)
+		}
+
+		if err == sql.ErrNoRows {
+			return UserConfig{}, errors.Wrap(ErrNotFound, "get user config")
+		}
+
+		return UserConfig{}, fmt.Errorf("get: %s", err)
+	}
+
+	return UserConfig{
+		baseID: raw.BaseID,
+		id:     raw.ID,
+	}, nil
+}
+
+func (r *pgUserRepo) Setup() error {
+	for _, q := range []string{
+		pgCreateSchema,
+		pgCreateTable,
+	} {
+		_, err := r.db.Exec(q)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *pgUserRepo) Teardown() error {
+	for _, q := range []string{
+		pgDropTable,
+	} {
+		_, err := r.db.Exec(q)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/config/postgres.go
+++ b/pkg/config/postgres.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type pgUserRepo struct {
+	db *sqlx.DB
+}
+
+// NewPostgresUserRepo returns a Postgres backed UserRepo implementation.
+func NewPostgresUserRepo(db *sqlx.DB) (UserRepo, error) {
+	return &pgUserRepo{
+		db: db,
+	}, nil
+}
+
+func (r *pgUserRepo) Get(baseName, id string) (*UserConfig, error) {
+	return nil, fmt.Errorf("pgUserRepo.Get() not implemented")
+}

--- a/pkg/config/postgres_test.go
+++ b/pkg/config/postgres_test.go
@@ -31,7 +31,7 @@ var (
 	pgURI string
 )
 
-func TestPostgresUserRepoGet(t *testing.T) {
+func TestPostgresUserRepoGetLatest(t *testing.T) {
 	var (
 		baseID = randString(characterSet)
 		userID = randString(numCharacterSet)
@@ -41,7 +41,7 @@ func TestPostgresUserRepoGet(t *testing.T) {
 		repo = preparePGUserRepo(t)
 	)
 
-	_, err := repo.Get(baseID, userID)
+	_, err := repo.GetLatest(baseID, userID)
 	if errors.Cause(err) != ErrNotFound {
 		t.Fatalf("expected ErrNotFound")
 	}
@@ -51,12 +51,27 @@ func TestPostgresUserRepoGet(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, err = repo.Put(
+		randString(characterSet),
+		randString(characterSet),
+		randString(numCharacterSet),
+		render,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Put(randString(characterSet), baseID, userID, map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	_, err = repo.Put(id.String(), baseID, userID, render)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	c, err := repo.Get(baseID, userID)
+	c, err := repo.GetLatest(baseID, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,6 +91,14 @@ func TestPostgresUserRepoGet(t *testing.T) {
 	if have, want := c.rendered, render; reflect.DeepEqual(have, want) {
 		t.Errorf("have %v, want %v", have, want)
 	}
+}
+
+func TestPostgresUserRepoGetNotFound(t *testing.T) {
+	t.Fail()
+}
+
+func TestPostgresUserRepoPutDuplicate(t *testing.T) {
+	t.Fail()
 }
 
 func randString(charset string) string {

--- a/pkg/config/postgres_test.go
+++ b/pkg/config/postgres_test.go
@@ -1,0 +1,9 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestPostgresUserRepoGet(t *testing.T) {
+	t.Fail()
+}

--- a/pkg/config/postgres_test.go
+++ b/pkg/config/postgres_test.go
@@ -1,9 +1,54 @@
+// +build integration
+
 package config
 
 import (
+	"flag"
+	"fmt"
+	"os/user"
 	"testing"
+
+	"github.com/jmoiron/sqlx"
+	// Blank import for Postgres capabilities.
+	_ "github.com/lib/pq"
+
+	"github.com/lifesum/configsum/pkg/pg"
 )
 
+var pgURI string
+
 func TestPostgresUserRepoGet(t *testing.T) {
-	t.Fail()
+	repo := preparePGUserRepo(t)
+
+	_, err := repo.Get("testName", "testID1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func preparePGUserRepo(t *testing.T) UserRepo {
+	db, err := sqlx.Connect("postgres", pgURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := NewPostgresUserRepo(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return r
+}
+
+func init() {
+	u, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+
+	uri := flag.String("postgres.uri", fmt.Sprintf(pg.DefaultTestURI, u.Username), "Postgres connection URL")
+
+	flag.Parse()
+
+	pgURI = *uri
 }

--- a/pkg/config/postgres_test.go
+++ b/pkg/config/postgres_test.go
@@ -5,8 +5,10 @@ package config
 import (
 	"flag"
 	"fmt"
+	"math/rand"
 	"os/user"
 	"testing"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	// Blank import for Postgres capabilities.
@@ -15,12 +17,29 @@ import (
 	"github.com/lifesum/configsum/pkg/pg"
 )
 
+const (
+	characterSet = "abcdefghijklmnopqrstuvwxyz" +
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	numCharacterSet = "0123456789"
+)
+
 var pgURI string
+var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func randString(charset string) string {
+	b := make([]byte, len(charset))
+
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+
+	return string(b)
+}
 
 func TestPostgresUserRepoGet(t *testing.T) {
 	repo := preparePGUserRepo(t)
 
-	_, err := repo.Get("testName", "testID1234")
+	_, err := repo.Get(randString(characterSet), randString(numCharacterSet))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/config/postgres_test.go
+++ b/pkg/config/postgres_test.go
@@ -33,11 +33,9 @@ var (
 
 func TestPostgresUserRepoGetLatest(t *testing.T) {
 	var (
-		baseID = randString(characterSet)
-		userID = randString(numCharacterSet)
-		render = rendered{
-			randString(numCharacterSet): seed.Float64(),
-		}
+		baseID  = randString(characterSet)
+		userID  = randString(numCharacterSet)
+		render  = rendered{}
 		repo    = preparePGUserRepo(t)
 		ruleIDs = []string{
 			randString(numCharacterSet),
@@ -45,6 +43,8 @@ func TestPostgresUserRepoGetLatest(t *testing.T) {
 			randString(numCharacterSet),
 		}
 	)
+
+	render.setNumber(randString(characterSet), seed.Float64())
 
 	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
 	if err != nil {
@@ -67,7 +67,7 @@ func TestPostgresUserRepoGetLatest(t *testing.T) {
 		baseID,
 		userID,
 		[]string{},
-		map[string]interface{}{},
+		rendered{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -119,11 +119,9 @@ func TestPostgresUserRepoGetLatestNotFound(t *testing.T) {
 
 func TestPostgresUserRepoAppendDuplicate(t *testing.T) {
 	var (
-		baseID = randString(characterSet)
-		userID = randString(numCharacterSet)
-		render = rendered{
-			randString(numCharacterSet): rand.Intn(128),
-		}
+		baseID  = randString(characterSet)
+		userID  = randString(numCharacterSet)
+		render  = rendered{}
 		repo    = preparePGUserRepo(t)
 		ruleIDs = []string{
 			randString(numCharacterSet),
@@ -131,6 +129,8 @@ func TestPostgresUserRepoAppendDuplicate(t *testing.T) {
 			randString(numCharacterSet),
 		}
 	)
+
+	render.SetBool(randString(numCharacterSet), false)
 
 	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
 	if err != nil {

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -14,12 +14,23 @@ type BaseConfig struct {
 
 // UserRepo provides access to user configs.
 type UserRepo interface {
-	Get(baseName, id string) (*UserConfig, error)
+	lifecycle
+
+	Get(baseName, id string) (UserConfig, error)
 }
 
 // UserConfig is a users rendered config.
 type UserConfig struct {
-	baseConfig string
-	userID     string
-	createdAt  time.Time
+	baseID      string
+	id          string
+	rendered    map[string]interface{}
+	ruleIDs     []string
+	userID      string
+	createdAt   time.Time
+	activatedAt time.Time
+}
+
+type lifecycle interface {
+	Setup() error
+	Teardown() error
 }

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -1,0 +1,25 @@
+package config
+
+import "time"
+
+// BaseRepo provides access to base configs.
+type BaseRepo interface {
+	Get(name string) (*BaseConfig, error)
+}
+
+// BaseConfig is the entire space of available parameters.
+type BaseConfig struct {
+	name string
+}
+
+// UserRepo provides access to user configs.
+type UserRepo interface {
+	Get(baseName, id string) (*UserConfig, error)
+}
+
+// UserConfig is a users rendered config.
+type UserConfig struct {
+	baseConfig string
+	userID     string
+	createdAt  time.Time
+}

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -18,8 +18,8 @@ type rendered map[string]interface{}
 type UserRepo interface {
 	lifecycle
 
+	Append(id, baseID, userID string, render rendered) (UserConfig, error)
 	GetLatest(baseID, userID string) (UserConfig, error)
-	Put(id, baseID, userID string, render rendered) (UserConfig, error)
 }
 
 // UserConfig is a users rendered config.

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -46,6 +46,9 @@ type UserRepo interface {
 	GetLatest(baseID, userID string) (UserConfig, error)
 }
 
+// UserRepoMiddleware is chainable behaviour modifier for UserRepo.
+type UserRepoMiddleware func(UserRepo) UserRepo
+
 // UserConfig is a users rendered config.
 type UserConfig struct {
 	baseID    string

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -14,6 +14,26 @@ type BaseConfig struct {
 
 type rendered map[string]interface{}
 
+func (r rendered) SetBool(key string, value bool) {
+	r[key] = value
+}
+
+func (r rendered) setNumber(key string, value float64) {
+	r[key] = value
+}
+
+func (r rendered) setNumberList(key string, value []float64) {
+	r[key] = value
+}
+
+func (r rendered) setString(key, value string) {
+	r[key] = value
+}
+
+func (r rendered) setStringList(key string, value []string) {
+	r[key] = value
+}
+
 // UserRepo provides access to user configs.
 type UserRepo interface {
 	lifecycle

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -18,19 +18,22 @@ type rendered map[string]interface{}
 type UserRepo interface {
 	lifecycle
 
-	Append(id, baseID, userID string, render rendered) (UserConfig, error)
+	Append(
+		id, baseID, userID string,
+		ruleIDs []string,
+		render rendered,
+	) (UserConfig, error)
 	GetLatest(baseID, userID string) (UserConfig, error)
 }
 
 // UserConfig is a users rendered config.
 type UserConfig struct {
-	baseID      string
-	id          string
-	rendered    rendered
-	ruleIDs     []string
-	userID      string
-	createdAt   time.Time
-	activatedAt time.Time
+	baseID    string
+	id        string
+	rendered  rendered
+	ruleIDs   []string
+	userID    string
+	createdAt time.Time
 }
 
 type lifecycle interface {

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -12,18 +12,21 @@ type BaseConfig struct {
 	name string
 }
 
+type rendered map[string]interface{}
+
 // UserRepo provides access to user configs.
 type UserRepo interface {
 	lifecycle
 
-	Get(baseName, id string) (UserConfig, error)
+	Get(baseID, userID string) (UserConfig, error)
+	Put(id, baseID, userID string, render rendered) (UserConfig, error)
 }
 
 // UserConfig is a users rendered config.
 type UserConfig struct {
 	baseID      string
 	id          string
-	rendered    map[string]interface{}
+	rendered    rendered
 	ruleIDs     []string
 	userID      string
 	createdAt   time.Time

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -18,7 +18,7 @@ type rendered map[string]interface{}
 type UserRepo interface {
 	lifecycle
 
-	Get(baseID, userID string) (UserConfig, error)
+	GetLatest(baseID, userID string) (UserConfig, error)
 	Put(id, baseID, userID string, render rendered) (UserConfig, error)
 }
 

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -1,0 +1,19 @@
+package config
+
+import "fmt"
+
+// ServiceUser provides user specific configs.
+type ServiceUser interface {
+	Get() error
+}
+
+type serviceUser struct{}
+
+// NewServiceUser provides user specific configs.
+func NewServiceUser() ServiceUser {
+	return &serviceUser{}
+}
+
+func (s *serviceUser) Get() error {
+	return fmt.Errorf("serviceUser.Get() not implemented")
+}

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -2,7 +2,7 @@ package config
 
 // ServiceUser provides user specific configs.
 type ServiceUser interface {
-	Get(baseConfig, userID string) (*UserConfig, error)
+	Get(baseConfig, userID string) (UserConfig, error)
 }
 
 type serviceUser struct {
@@ -18,11 +18,11 @@ func NewServiceUser(baseRepo BaseRepo, userRepo UserRepo) ServiceUser {
 	}
 }
 
-func (s *serviceUser) Get(baseConfig, userID string) (*UserConfig, error) {
+func (s *serviceUser) Get(baseConfig, userID string) (UserConfig, error) {
 	// lookup base config
 	bc, err := s.baseRepo.Get(baseConfig)
 	if err != nil {
-		return nil, err
+		return UserConfig{}, err
 	}
 
 	// lookup current config by userID

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -26,7 +26,7 @@ func (s *serviceUser) Get(baseConfig, userID string) (UserConfig, error) {
 	}
 
 	// lookup current config by userID
-	return s.userRepo.Get(bc.name, userID)
+	return s.userRepo.GetLatest(bc.name, userID)
 
 	// compare configs
 	// store config

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -27,7 +27,6 @@ func (s *serviceUser) Get(baseConfig, userID string) (UserConfig, error) {
 
 	// lookup current config by userID
 	return s.userRepo.GetLatest(bc.name, userID)
-
 	// compare configs
 	// store config
 	// return rendered config

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -1,10 +1,16 @@
 package config
 
-import "fmt"
+import (
+	"time"
+)
 
 // ServiceUser provides user specific configs.
 type ServiceUser interface {
-	Get() error
+	Get() (config, error)
+}
+
+type config struct {
+	createdAt time.Time
 }
 
 type serviceUser struct{}
@@ -14,6 +20,6 @@ func NewServiceUser() ServiceUser {
 	return &serviceUser{}
 }
 
-func (s *serviceUser) Get() error {
-	return fmt.Errorf("serviceUser.Get() not implemented")
+func (s *serviceUser) Get() (config, error) {
+	return config{createdAt: time.Now()}, nil
 }

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -6,11 +6,12 @@ import (
 
 // ServiceUser provides user specific configs.
 type ServiceUser interface {
-	Get() (config, error)
+	Get(baseConfig string) (config, error)
 }
 
 type config struct {
-	createdAt time.Time
+	baseConfig string
+	createdAt  time.Time
 }
 
 type serviceUser struct{}
@@ -20,6 +21,14 @@ func NewServiceUser() ServiceUser {
 	return &serviceUser{}
 }
 
-func (s *serviceUser) Get() (config, error) {
-	return config{createdAt: time.Now()}, nil
+func (s *serviceUser) Get(baseConfig string) (config, error) {
+	// lookup base config
+	// lookup current config
+	// apply rules to base config
+	// compare configs
+	// return is newer
+	return config{
+		baseConfig: baseConfig,
+		createdAt:  time.Now(),
+	}, nil
 }

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -1,34 +1,34 @@
 package config
 
-import (
-	"time"
-)
-
 // ServiceUser provides user specific configs.
 type ServiceUser interface {
-	Get(baseConfig string) (config, error)
+	Get(baseConfig, userID string) (*UserConfig, error)
 }
 
-type config struct {
-	baseConfig string
-	createdAt  time.Time
+type serviceUser struct {
+	baseRepo BaseRepo
+	userRepo UserRepo
 }
-
-type serviceUser struct{}
 
 // NewServiceUser provides user specific configs.
-func NewServiceUser() ServiceUser {
-	return &serviceUser{}
+func NewServiceUser(baseRepo BaseRepo, userRepo UserRepo) ServiceUser {
+	return &serviceUser{
+		baseRepo: baseRepo,
+		userRepo: userRepo,
+	}
 }
 
-func (s *serviceUser) Get(baseConfig string) (config, error) {
+func (s *serviceUser) Get(baseConfig, userID string) (*UserConfig, error) {
 	// lookup base config
-	// lookup current config
-	// apply rules to base config
+	bc, err := s.baseRepo.Get(baseConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// lookup current config by userID
+	return s.userRepo.Get(bc.name, userID)
+
 	// compare configs
-	// return is newer
-	return config{
-		baseConfig: baseConfig,
-		createdAt:  time.Now(),
-	}, nil
+	// store config
+	// return rendered config
 }

--- a/pkg/config/transport.go
+++ b/pkg/config/transport.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-kit/kit/log"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+)
+
+// MakeHandler returns an http.Handler for the config service.
+func MakeHandler(logger log.Logger, svc ServiceUser) http.Handler {
+	r := mux.NewRouter()
+	r.StrictSlash(true)
+
+	r.Methods("PUT").Path(`/{baseConfig:[a-z0-9]+}`).Name("configUser").Handler(
+		kithttp.NewServer(
+			userEndpoint(svc),
+			decodeUserRequest,
+			kithttp.EncodeJSONResponse,
+		),
+	)
+
+	return r
+}
+
+func decodeUserRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	return userRequest{}, nil
+}

--- a/pkg/config/transport.go
+++ b/pkg/config/transport.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/go-kit/kit/log"
@@ -26,5 +27,9 @@ func MakeHandler(logger log.Logger, svc ServiceUser) http.Handler {
 }
 
 func decodeUserRequest(ctx context.Context, r *http.Request) (interface{}, error) {
-	return userRequest{}, nil
+	c, ok := mux.Vars(r)["baseConfig"]
+	if !ok {
+		return nil, fmt.Errorf("Baseconfig missing")
+	}
+	return userRequest{baseConfig: c}, nil
 }

--- a/pkg/pg/pg.go
+++ b/pkg/pg/pg.go
@@ -1,0 +1,7 @@
+package pg
+
+// Default URIs.
+const (
+	DefaultDevURI  = "postgres://%s@127.0.0.1:5432/configsum_dev?sslmode=disable&connect_timeout=5"
+	DefaultTestURI = "postgres://%s@127.0.0.1:5432/configsum_test?sslmode=disable&connect_timeout=5"
+)

--- a/pkg/pg/pg.go
+++ b/pkg/pg/pg.go
@@ -1,7 +1,38 @@
 package pg
 
+import (
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
 // Default URIs.
 const (
 	DefaultDevURI  = "postgres://%s@127.0.0.1:5432/configsum_dev?sslmode=disable&connect_timeout=5"
 	DefaultTestURI = "postgres://%s@127.0.0.1:5432/configsum_test?sslmode=disable&connect_timeout=5"
 )
+
+const (
+	codeRelationshipNotFound = "42P01"
+)
+
+// Errors.
+var (
+	ErrRelationNotFound = errors.New("relation not found")
+)
+
+// IsRelationNotFound indicates if err is ErrRelationNotFound.
+func IsRelationNotFound(err error) bool {
+	return err == ErrRelationNotFound
+}
+
+// Wrap translates *pq.Error codes into actionable errors.
+func Wrap(err error) error {
+	if e, ok := err.(*pq.Error); ok {
+		switch e.Code {
+		case codeRelationshipNotFound:
+			return ErrRelationNotFound
+		}
+	}
+
+	return err
+}

--- a/pkg/pg/pg.go
+++ b/pkg/pg/pg.go
@@ -12,11 +12,13 @@ const (
 )
 
 const (
-	codeRelationshipNotFound = "42P01"
+	codeDuplicateKeyViolation = "23505"
+	codeRelationshipNotFound  = "42P01"
 )
 
 // Errors.
 var (
+	ErrDuplicateKey     = errors.New("duplicate key")
 	ErrRelationNotFound = errors.New("relation not found")
 )
 
@@ -29,6 +31,8 @@ func IsRelationNotFound(err error) bool {
 func Wrap(err error) error {
 	if e, ok := err.(*pq.Error); ok {
 		switch e.Code {
+		case codeDuplicateKeyViolation:
+			return ErrDuplicateKey
 		case codeRelationshipNotFound:
 			return ErrRelationNotFound
 		}


### PR DESCRIPTION
This change-set sketches up the main scaffold of the Go backend of the repository. Additonally it drafts the config package which is at the heart of the Configsum domain. For guiding purposes on the general layout of the project might look, we followed along the config example to touch on all major concerns of domain entity creation, from providing a service implementation which can be mounted onto an HTTP server to database specific implementations of repositories. Additionally we expose telemetry and handle logging. We assume this can serve as an example on how to package backend additions for production.