### PR TITLE
Store results of rule decisions

### DIFF
--- a/cmd/configsum/config.go
+++ b/cmd/configsum/config.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	kitprom "github.com/go-kit/kit/metrics/prometheus"
+	"github.com/jmoiron/sqlx"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/lifesum/configsum/pkg/config"
+)
+
+func runConfig(args []string, logger log.Logger) error {
+	var (
+		begin   = time.Now()
+		flagset = flag.NewFlagSet("config", flag.ExitOnError)
+
+		intrumentAddr = flagset.String("instrument.addir", ":8701", "Listen address for instrumentation")
+		listenAddr    = flagset.String("listen.addr", ":8700", "Listen address for HTTP API")
+		postgresURI   = flagset.String("postgres.uri", defaultPostgresURI, "URI for Posgres connection")
+	)
+
+	flagset.Usage = usageCmd(flagset, "config [flags]")
+	if err := flagset.Parse(args); err != nil {
+		return err
+	}
+
+	// Setup instrunentation.
+	go func(logger log.Logger, addr string) {
+		mux := http.NewServeMux()
+
+		registerMetrics(mux)
+		registerProfile(mux)
+
+		logger.Log(
+			logDuration, time.Since(begin).Nanoseconds(),
+			logLifecycle, lifecycleStart,
+			logListen, addr,
+			logService, "instrument",
+		)
+
+		abort(logger, http.ListenAndServe(addr, mux))
+	}(logger, *intrumentAddr)
+
+	repoLabels := []string{
+		labelOp,
+		labelRepo,
+		labelStore,
+	}
+
+	repoErrCount := kitprom.NewCounterFrom(
+		prometheus.CounterOpts{
+			Namespace: instrumentNamespace,
+			Subsystem: instrumentSubsystem,
+			Name:      "err_count",
+			Help:      "Amount of failed repo operations.",
+		},
+		repoLabels,
+	)
+
+	repoErrCountFunc := func(store, repo, op string) {
+		repoErrCount.With(
+			labelOp, op,
+			labelRepo, repo,
+			labelStore, store,
+		).Add(1)
+	}
+
+	repoOpCount := kitprom.NewCounterFrom(
+		prometheus.CounterOpts{
+			Namespace: instrumentNamespace,
+			Subsystem: instrumentSubsystem,
+			Name:      "op_count",
+			Help:      "Amount of successful repo operations.",
+		},
+		repoLabels,
+	)
+
+	repoOpCountFunc := func(store, repo, op string) {
+		repoOpCount.With(
+			labelOp, op,
+			labelRepo, repo,
+			labelStore, store,
+		).Add(1)
+	}
+
+	repoOpLatency := kitprom.NewHistogramFrom(
+		prometheus.HistogramOpts{
+			Namespace: instrumentNamespace,
+			Subsystem: instrumentSubsystem,
+			Name:      "op_latency_seconds",
+			Help:      "Latency of successful repo operations.",
+		},
+		repoLabels,
+	)
+
+	repoOpLatencyFunc := func(store, repo, op string, begin time.Time) {
+		repoOpLatency.With(
+			labelOp, op,
+			labelRepo, repo,
+			labelStore, store,
+		).Observe(time.Since(begin).Seconds())
+	}
+
+	// Setup clients.
+	db, err := sqlx.Connect(storeRepo, *postgresURI)
+	if err != nil {
+		return err
+	}
+
+	// Setup repos.
+	baseRepo, err := config.NewInmemBaseRepo()
+	if err != nil {
+		return err
+	}
+
+	userRepo, err := config.NewPostgresUserRepo(db)
+	if err != nil {
+		return err
+	}
+	userRepo = config.NewUserRepoInstrumentMiddleware(
+		repoErrCountFunc,
+		repoOpCountFunc,
+		repoOpLatencyFunc,
+		storeRepo,
+	)(userRepo)
+	userRepo = config.NewUserRepoLogMiddleware(logger, storeRepo)(userRepo)
+
+	// Setup service.
+	var (
+		mux          = http.NewServeMux()
+		prefixConfig = fmt.Sprintf(`/%s/config`, apiVersion)
+		svc          = config.NewServiceUser(baseRepo, userRepo)
+	)
+
+	mux.Handle(
+		fmt.Sprintf(`%s/`, prefixConfig),
+		http.StripPrefix(
+			prefixConfig,
+			config.MakeHandler(logger, svc),
+		),
+	)
+
+	// Setup server.
+	srv := &http.Server{
+		Addr:         *listenAddr,
+		Handler:      mux,
+		ReadTimeout:  defaultTimeoutRead,
+		WriteTimeout: defaultTimeoutWrite,
+	}
+
+	_ = level.Info(logger).Log(
+		logDuration, time.Since(begin).Nanoseconds(),
+		logLifecycle, lifecycleStart,
+		logListen, *listenAddr,
+		logService, "api",
+	)
+
+	return srv.ListenAndServe()
+}

--- a/pkg/config/inmem.go
+++ b/pkg/config/inmem.go
@@ -27,7 +27,7 @@ func NewInmemUserRepo() (UserRepo, error) {
 
 func (r *inmemUserRepo) Append(
 	id, baseID, userID string,
-	ruleIDs []string,
+	decisions ruleDecisions,
 	render rendered,
 ) (UserConfig, error) {
 	return UserConfig{}, fmt.Errorf("inmemUserRepo.Put() not implemented")

--- a/pkg/config/instrument.go
+++ b/pkg/config/instrument.go
@@ -38,14 +38,14 @@ func NewUserRepoInstrumentMiddleware(
 
 func (r *instrumentUserRepo) Append(
 	id, baseID, userID string,
-	ruleIDs []string,
+	decisions ruleDecisions,
 	render rendered,
 ) (c UserConfig, err error) {
 	defer func(begin time.Time) {
 		r.track(begin, err, "Append")
 	}(time.Now())
 
-	return r.next.Append(id, baseID, userID, ruleIDs, render)
+	return r.next.Append(id, baseID, userID, decisions, render)
 }
 
 func (r *instrumentUserRepo) GetLatest(

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -8,17 +8,17 @@ import (
 
 // Log fields.
 const (
-	logBaseID   = "baseId"
-	logDuration = "duration"
-	logErr      = "err"
-	logID       = "id"
-	logOp       = "op"
-	logPkg      = "pkg"
-	logRendered = "rendered"
-	logRepo     = "repo"
-	logRuleIDs  = "ruleIds"
-	logStore    = "store"
-	logUserID   = "userId"
+	logBaseID        = "baseId"
+	logDuration      = "duration"
+	logErr           = "err"
+	logID            = "id"
+	logOp            = "op"
+	logPkg           = "pkg"
+	logRendered      = "rendered"
+	logRepo          = "repo"
+	logRuleDecisions = "ruleDecisions"
+	logStore         = "store"
+	logUserID        = "userId"
 )
 
 type logUserRepo struct {
@@ -43,7 +43,7 @@ func NewUserRepoLogMiddleware(logger log.Logger, store string) UserRepoMiddlewar
 
 func (r *logUserRepo) Append(
 	id, baseID, userID string,
-	ruleIDs []string,
+	decisions ruleDecisions,
 	render rendered,
 ) (c UserConfig, err error) {
 	defer func(begin time.Time) {
@@ -53,7 +53,7 @@ func (r *logUserRepo) Append(
 			logID, id,
 			logOp, "Append",
 			logRendered, render,
-			logRuleIDs, ruleIDs,
+			logRuleDecisions, decisions,
 			logUserID, userID,
 		}
 
@@ -64,7 +64,7 @@ func (r *logUserRepo) Append(
 		_ = r.logger.Log(ps...)
 	}(time.Now())
 
-	return r.next.Append(id, baseID, userID, ruleIDs, render)
+	return r.next.Append(id, baseID, userID, decisions, render)
 }
 
 func (r *logUserRepo) GetLatest(baseID, userID string) (c UserConfig, err error) {

--- a/pkg/config/postgres_test.go
+++ b/pkg/config/postgres_test.go
@@ -33,14 +33,14 @@ var (
 
 func TestPostgresUserRepoGetLatest(t *testing.T) {
 	var (
-		baseID  = randString(characterSet)
-		userID  = randString(numCharacterSet)
-		render  = rendered{}
-		repo    = preparePGUserRepo(t)
-		ruleIDs = []string{
-			randString(numCharacterSet),
-			randString(numCharacterSet),
-			randString(numCharacterSet),
+		baseID    = randString(characterSet)
+		userID    = randString(numCharacterSet)
+		render    = rendered{}
+		repo      = preparePGUserRepo(t)
+		decisions = ruleDecisions{
+			randString(numCharacterSet): []int{seed.Intn(100), seed.Intn(100)},
+			randString(numCharacterSet): []int{seed.Intn(100)},
+			randString(numCharacterSet): []int{},
 		}
 	)
 
@@ -55,7 +55,7 @@ func TestPostgresUserRepoGetLatest(t *testing.T) {
 		randString(characterSet),
 		randString(characterSet),
 		randString(numCharacterSet),
-		ruleIDs,
+		decisions,
 		render,
 	)
 	if err != nil {
@@ -66,14 +66,14 @@ func TestPostgresUserRepoGetLatest(t *testing.T) {
 		randString(characterSet),
 		baseID,
 		userID,
-		[]string{},
+		nil,
 		rendered{},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = repo.Append(id.String(), baseID, userID, ruleIDs, render)
+	_, err = repo.Append(id.String(), baseID, userID, decisions, render)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestPostgresUserRepoGetLatest(t *testing.T) {
 		t.Errorf("\nhave %#v,\nwant %#v", have, want)
 	}
 
-	if have, want := c.ruleIDs, ruleIDs; !reflect.DeepEqual(have, want) {
+	if have, want := c.ruleDecisions, decisions; !reflect.DeepEqual(have, want) {
 		t.Errorf("have %v, want %v", have, want)
 	}
 }
@@ -119,14 +119,14 @@ func TestPostgresUserRepoGetLatestNotFound(t *testing.T) {
 
 func TestPostgresUserRepoAppendDuplicate(t *testing.T) {
 	var (
-		baseID  = randString(characterSet)
-		userID  = randString(numCharacterSet)
-		render  = rendered{}
-		repo    = preparePGUserRepo(t)
-		ruleIDs = []string{
-			randString(numCharacterSet),
-			randString(numCharacterSet),
-			randString(numCharacterSet),
+		baseID    = randString(characterSet)
+		userID    = randString(numCharacterSet)
+		render    = rendered{}
+		repo      = preparePGUserRepo(t)
+		decisions = ruleDecisions{
+			randString(numCharacterSet): []int{seed.Int(), seed.Int()},
+			randString(numCharacterSet): []int{seed.Int()},
+			randString(numCharacterSet): []int{},
 		}
 	)
 
@@ -137,12 +137,12 @@ func TestPostgresUserRepoAppendDuplicate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = repo.Append(id.String(), baseID, userID, ruleIDs, render)
+	_, err = repo.Append(id.String(), baseID, userID, decisions, render)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = repo.Append(id.String(), baseID, userID, ruleIDs, render)
+	_, err = repo.Append(id.String(), baseID, userID, decisions, render)
 	if have, want := errors.Cause(err), ErrExists; have != want {
 		t.Errorf("have %v, want %v", have, want)
 	}

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -34,13 +34,17 @@ func (r rendered) setStringList(key string, value []string) {
 	r[key] = value
 }
 
+// ruleDecisions reflects a matrix of rules applied to a config and if present
+// the results of dice rolls for percenatage based decisions.
+type ruleDecisions map[string][]int
+
 // UserRepo provides access to user configs.
 type UserRepo interface {
 	lifecycle
 
 	Append(
 		id, baseID, userID string,
-		ruleIDs []string,
+		decisiosn ruleDecisions,
 		render rendered,
 	) (UserConfig, error)
 	GetLatest(baseID, userID string) (UserConfig, error)
@@ -51,12 +55,12 @@ type UserRepoMiddleware func(UserRepo) UserRepo
 
 // UserConfig is a users rendered config.
 type UserConfig struct {
-	baseID    string
-	id        string
-	rendered  rendered
-	ruleIDs   []string
-	userID    string
-	createdAt time.Time
+	baseID        string
+	id            string
+	rendered      rendered
+	ruleDecisions ruleDecisions
+	userID        string
+	createdAt     time.Time
 }
 
 type lifecycle interface {


### PR DESCRIPTION
As rendered configs rely on decisions made in rules and those potentially be random in nature, for example a dice roll to determine the bucket of an experiment, we need to store the results in order to
deterministically deliver the same experience to a user. We express this with a list of integers which could be used to represents dice rolls for percentage-based rollout, bucket assignment and more unforeseen at this point.

* introduce ruleDecisions type
* change user repo interface to expect rule decisions
* update postgres implementation to store decisions as json blob