### PR TITLE
Enable dynamic base for Console ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 	@echo "make ui-compile-watch     Recompiles the Elm code on file changes (requires elm-live)"
 
 run-console:
-	cd ui && go run ../cmd/configsum/*.go console -static.local
+	cd ui && go run ../cmd/configsum/*.go console -ui.local
 
 setup-dev:
 	psql -d template1 -tc "SELECT 1 FROM pg_database WHERE datname = 'configsum_dev'" | grep -q 1 || psql -d template1 -c "CREATE DATABASE configsum_dev"

--- a/cmd/configsum/console.go
+++ b/cmd/configsum/console.go
@@ -18,7 +18,8 @@ func runConsole(args []string, logger log.Logger) error {
 
 		instrumentAddr = flagset.String("instrument.addr", ":8711", "Listen address for instrumenation")
 		listenAddr     = flagset.String("listen.addr", ":8710", "HTTP API bind address")
-		staticLocal    = flagset.Bool("static.local", false, "Determines if static assets are loaded from the filesystem.")
+		uiBase         = flagset.String("ui.base", "/", "Base URI to use for path based mounting")
+		uiLocal        = flagset.Bool("ui.local", false, "Load static assets from the filesystem")
 	)
 
 	flagset.Usage = usageCmd(flagset, "console [flags]")
@@ -44,7 +45,7 @@ func runConsole(args []string, logger log.Logger) error {
 
 	serveMux := http.NewServeMux()
 
-	handler, err := ui.MakeHandler(logger, *staticLocal)
+	handler, err := ui.MakeHandler(logger, *uiBase, *uiLocal)
 	if err != nil {
 		abort(logger, err)
 	}

--- a/pkg/ui/transport.go
+++ b/pkg/ui/transport.go
@@ -12,10 +12,11 @@ const tmplIndex = `<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
+    <base href="{{ .Base }}">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono|Roboto:300,400,500,700" rel="stylesheet">
-    <link href="/styles/normalize.css" rel="stylesheet">
-    <link href="/styles/console.css" rel="stylesheet">
-    <script src="/scripts/console.js" type="text/javascript"></script>
+    <link href="styles/normalize.css" rel="stylesheet">
+    <link href="styles/console.css" rel="stylesheet">
+    <script src="scripts/console.js" type="text/javascript"></script>
   </head>
   <body>
     <script type="text/javascript">
@@ -25,7 +26,7 @@ const tmplIndex = `<!DOCTYPE html>
 </html>`
 
 // MakeHandler returns am http.Handler for the UI.
-func MakeHandler(logger log.Logger, local bool) (http.Handler, error) {
+func MakeHandler(logger log.Logger, base string, local bool) (http.Handler, error) {
 	r := mux.NewRouter()
 
 	tplRoot, err := template.New("root").Parse(tmplIndex)
@@ -43,7 +44,11 @@ func MakeHandler(logger log.Logger, local bool) (http.Handler, error) {
 
 	r.Methods("GET").PathPrefix("/").Name("root").HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			tplRoot.Execute(w, nil)
+			tplRoot.Execute(w, struct {
+				Base string
+			}{
+				Base: base,
+			})
 		},
 	)
 

--- a/ui/src/Route.elm
+++ b/ui/src/Route.elm
@@ -40,7 +40,7 @@ routeToString route =
                 Rules ->
                     [ "rules" ]
     in
-        "/" ++ String.join "/" pieces
+        String.join "/" pieces
 
 
 


### PR DESCRIPTION
In order to have operational flexibility for UI mounting in production we support a configurable base tag and have all links dynamic.

* add `ui.base` flag
* asset links relative
* routes relative