### PR TITLE
 Implement public token based AuthMiddleware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ help:
 	@echo "make ui-compile           Compiles Elm code to Javascript (requires elm-make)"
 	@echo "make ui-compile-watch     Recompiles the Elm code on file changes (requires elm-live)"
 
+run-config:
+	go run ./cmd/configsum/*.go config
+
 run-console:
 	cd ui && go run ../cmd/configsum/*.go console -ui.local
 

--- a/cmd/configsum/config.go
+++ b/cmd/configsum/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/lifesum/configsum/pkg/client"
 	"github.com/lifesum/configsum/pkg/config"
 )
 
@@ -131,10 +132,29 @@ func runConfig(args []string, logger log.Logger) error {
 	)(userRepo)
 	userRepo = config.NewUserRepoLogMiddleware(logger, storeRepo)(userRepo)
 
+	clientRepo := client.NewPostgresRepo(db)
+	clientRepo = client.NewRepoInstrumentMiddleware(
+		repoErrCountFunc,
+		repoOpCountFunc,
+		repoOpLatencyFunc,
+		storeRepo,
+	)(clientRepo)
+	clientRepo = client.NewRepoLogMiddleware(logger, storeRepo)(clientRepo)
+
+	tokenRepo := client.NewPostgresTokenRepo(db)
+	tokenRepo = client.NewTokenRepoInstrumentMiddleware(
+		repoErrCountFunc,
+		repoOpCountFunc,
+		repoOpLatencyFunc,
+		storeRepo,
+	)(tokenRepo)
+	tokenRepo = client.NewTokenRepoLogMiddleware(logger, storeRepo)(tokenRepo)
+
 	// Setup service.
 	var (
 		mux          = http.NewServeMux()
 		prefixConfig = fmt.Sprintf(`/%s/config`, apiVersion)
+		clientSvc    = client.NewService(clientRepo, tokenRepo)
 		svc          = config.NewServiceUser(baseRepo, userRepo)
 	)
 
@@ -142,7 +162,7 @@ func runConfig(args []string, logger log.Logger) error {
 		fmt.Sprintf(`%s/`, prefixConfig),
 		http.StripPrefix(
 			prefixConfig,
-			config.MakeHandler(logger, svc),
+			config.MakeHandler(logger, svc, clientSvc),
 		),
 	)
 

--- a/pkg/client/error.go
+++ b/pkg/client/error.go
@@ -6,5 +6,6 @@ import (
 
 // Common errors.
 var (
-	ErrNotFound = errors.New("entity not found")
+	ErrNotFound      = errors.New("entity not found")
+	ErrSecretMissing = errors.New("missing secret")
 )

--- a/pkg/client/inmen.go
+++ b/pkg/client/inmen.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type inmemRepo struct {
+	clients map[string]Client
+}
+
+// NewInmemRepo returns a memory backed Repo implementation.
+func NewInmemRepo() Repo {
+	return &inmemRepo{
+		clients: map[string]Client{},
+	}
+}
+
+func (r *inmemRepo) Lookup(id string) (Client, error) {
+	c, ok := r.clients[id]
+	if !ok {
+		return Client{}, errors.Wrap(ErrNotFound, "client lookup")
+	}
+
+	return c, nil
+}
+
+func (r *inmemRepo) Store(id, name string) (Client, error) {
+	c := Client{
+		id:        id,
+		name:      name,
+		createdAt: time.Now(),
+	}
+
+	r.clients[id] = c
+
+	return c, nil
+}
+
+func (r *inmemRepo) setup() error {
+	return nil
+}
+
+func (r *inmemRepo) teardown() error {
+	return nil
+}
+
+type inmemTokenRepo struct {
+	tokens map[string]Token
+}
+
+// NewInmemTokenRepo returns a memory backed Repo implementation.
+func NewInmemTokenRepo() TokenRepo {
+	return &inmemTokenRepo{
+		tokens: map[string]Token{},
+	}
+}
+
+func (r *inmemTokenRepo) Lookup(secret string) (Token, error) {
+	t, ok := r.tokens[secret]
+	if !ok {
+		return Token{}, errors.Wrap(ErrNotFound, "token lookup")
+	}
+
+	return t, nil
+}
+
+func (r *inmemTokenRepo) Store(clientID, secret string) (Token, error) {
+	t := Token{
+		clientID:  clientID,
+		secret:    secret,
+		createdAt: time.Now(),
+	}
+
+	r.tokens[secret] = t
+
+	return t, nil
+}
+
+func (r *inmemTokenRepo) setup() error {
+	return nil
+}
+
+func (r *inmemTokenRepo) teardown() error {
+	return nil
+}

--- a/pkg/client/inmen_test.go
+++ b/pkg/client/inmen_test.go
@@ -1,0 +1,27 @@
+package client
+
+import "testing"
+
+func TestInmemRepoLookup(t *testing.T) {
+	testRepoLookup(t, prepareInmemRepo)
+}
+
+func TestInmemRepoLookupNotFound(t *testing.T) {
+	testRepoLookupNotFound(t, prepareInmemRepo)
+}
+
+func TestInmemTokenRepoLookup(t *testing.T) {
+	testTokenRepoLookup(t, prepareInmemTokenRepo)
+}
+
+func TestInmemTokenRepoLookupNotFound(t *testing.T) {
+	testTokenRepoLookupNotFound(t, prepareInmemTokenRepo)
+}
+
+func prepareInmemRepo(t *testing.T) Repo {
+	return NewInmemRepo()
+}
+
+func prepareInmemTokenRepo(t *testing.T) TokenRepo {
+	return NewInmemTokenRepo()
+}

--- a/pkg/client/instrument.go
+++ b/pkg/client/instrument.go
@@ -1,0 +1,147 @@
+package client
+
+import "time"
+
+const (
+	labelRepo      = "client"
+	labelRepoToken = "token"
+)
+
+type countFunc func(store, repo, op string)
+type observeFunc func(store, repo, op string, begin time.Time)
+
+type instrumentRepo struct {
+	errCount  countFunc
+	opCount   countFunc
+	opObserve observeFunc
+	next      Repo
+	store     string
+}
+
+// NewRepoInstrumentMiddleware wraps the next Repo with Prometheus
+// instrumenation capabilities.
+func NewRepoInstrumentMiddleware(
+	errCount countFunc,
+	opCount countFunc,
+	opObserve observeFunc,
+	store string,
+) RepoMiddleware {
+	return func(next Repo) Repo {
+		return &instrumentRepo{
+			errCount:  errCount,
+			next:      next,
+			opCount:   opCount,
+			opObserve: opObserve,
+			store:     store,
+		}
+	}
+}
+
+func (r *instrumentRepo) Lookup(id string) (client Client, err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "Lookup")
+	}(time.Now())
+
+	return r.next.Lookup(id)
+}
+
+func (r *instrumentRepo) Store(id, name string) (client Client, err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "Store")
+	}(time.Now())
+
+	return r.next.Store(id, name)
+}
+
+func (r *instrumentRepo) setup() (err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "setup")
+	}(time.Now())
+
+	return r.next.setup()
+}
+
+func (r *instrumentRepo) teardown() (err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "teardown")
+	}(time.Now())
+
+	return r.next.teardown()
+}
+
+func (r *instrumentRepo) track(begin time.Time, err error, op string) {
+	if err != nil {
+		r.errCount(r.store, labelRepo, op)
+	}
+
+	r.opCount(r.store, labelRepo, op)
+	r.opObserve(r.store, labelRepo, op, begin)
+}
+
+type instrumentTokenRepo struct {
+	errCount  countFunc
+	opCount   countFunc
+	opObserve observeFunc
+	next      TokenRepo
+	store     string
+}
+
+// NewTokenRepoInstrumentMiddleware wraps the next TokenRepo with Prometheus
+// instrumenation capabilities.
+func NewTokenRepoInstrumentMiddleware(
+	errCount countFunc,
+	opCount countFunc,
+	opObserve observeFunc,
+	store string,
+) TokenRepoMiddleware {
+	return func(next TokenRepo) TokenRepo {
+		return &instrumentTokenRepo{
+			errCount:  errCount,
+			next:      next,
+			opCount:   opCount,
+			opObserve: opObserve,
+			store:     store,
+		}
+	}
+}
+
+func (r *instrumentTokenRepo) Lookup(secret string) (token Token, err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "Lookup")
+	}(time.Now())
+
+	return r.next.Lookup(secret)
+}
+
+func (r *instrumentTokenRepo) Store(clientID, secret string) (token Token, err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "Store")
+	}(time.Now())
+
+	return r.next.Store(clientID, secret)
+}
+
+func (r *instrumentTokenRepo) setup() (err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "setup")
+	}(time.Now())
+
+	return r.next.setup()
+}
+
+func (r *instrumentTokenRepo) teardown() (err error) {
+	defer func(begin time.Time) {
+		r.track(begin, err, "teardown")
+	}(time.Now())
+
+	return r.next.teardown()
+}
+
+func (r *instrumentTokenRepo) track(begin time.Time, err error, op string) {
+	if err != nil {
+		r.errCount(r.store, labelRepoToken, op)
+	}
+
+	r.opCount(r.store, labelRepoToken, op)
+	r.opObserve(r.store, labelRepoToken, op, begin)
+}

--- a/pkg/client/logging.go
+++ b/pkg/client/logging.go
@@ -1,0 +1,199 @@
+package client
+
+import (
+	"time"
+
+	"github.com/go-kit/kit/log"
+)
+
+// Log fields.
+const (
+	logFieldClientID = "client_id"
+	logFieldDuration = "duration"
+	logFieldErr      = "err"
+	logFieldID       = "id"
+	logFieldOp       = "op"
+	logFieldPkg      = "pkg"
+	logFieldRepo     = "repo"
+	logFieldSecret   = "secret"
+	logFieldStore    = "store"
+)
+
+type logRepo struct {
+	logger log.Logger
+	next   Repo
+}
+
+// NewRepoLogMiddleware wraps the next Repo with logging capabilities.
+func NewRepoLogMiddleware(logger log.Logger, store string) RepoMiddleware {
+	return func(next Repo) Repo {
+		return &logRepo{
+			logger: log.With(
+				logger,
+				logFieldPkg, "client",
+				logFieldRepo, labelRepo,
+			),
+			next: next,
+		}
+	}
+}
+
+func (r *logRepo) Lookup(id string) (client Client, err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logFieldDuration, time.Since(begin).Nanoseconds(),
+			logFieldID, id,
+			logFieldOp, "Lookup",
+		}
+
+		if err != nil {
+			ps = append(ps, logFieldErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.Lookup(id)
+}
+
+func (r *logRepo) Store(id, name string) (client Client, err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logFieldDuration, time.Since(begin).Nanoseconds(),
+			logFieldID, id,
+			logFieldOp, "Store",
+		}
+
+		if err != nil {
+			ps = append(ps, logFieldErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.Store(id, name)
+}
+
+func (r *logRepo) setup() (err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logFieldDuration, time.Since(begin).Nanoseconds(),
+			logFieldOp, "setup",
+		}
+
+		if err != nil {
+			ps = append(ps, logFieldErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.setup()
+}
+
+func (r *logRepo) teardown() (err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logFieldDuration, time.Since(begin).Nanoseconds(),
+			logFieldOp, "teardown",
+		}
+
+		if err != nil {
+			ps = append(ps, logFieldErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.teardown()
+}
+
+type logTokenRepo struct {
+	logger log.Logger
+	next   TokenRepo
+}
+
+// NewTokenRepoLogMiddleware wraps the next TokenRepo with logging capabilities.
+func NewTokenRepoLogMiddleware(logger log.Logger, store string) TokenRepoMiddleware {
+	return func(next TokenRepo) TokenRepo {
+		return &logTokenRepo{
+			logger: log.With(
+				logger,
+				logFieldPkg, "client",
+				logFieldRepo, labelRepoToken,
+			),
+			next: next,
+		}
+	}
+}
+
+func (r *logTokenRepo) Lookup(secret string) (token Token, err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logFieldDuration, time.Since(begin).Nanoseconds(),
+			logFieldOp, "Lookup",
+			logFieldSecret, secret,
+		}
+
+		if err != nil {
+			ps = append(ps, logFieldErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.Lookup(secret)
+}
+
+func (r *logTokenRepo) Store(clientID, secret string) (token Token, err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logFieldDuration, time.Since(begin).Nanoseconds(),
+			logFieldClientID, clientID,
+			logFieldOp, "Store",
+			logFieldSecret, secret,
+		}
+
+		if err != nil {
+			ps = append(ps, logFieldErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.Store(clientID, secret)
+}
+
+func (r *logTokenRepo) setup() (err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logFieldDuration, time.Since(begin).Nanoseconds(),
+			logFieldOp, "setup",
+		}
+
+		if err != nil {
+			ps = append(ps, logFieldErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.setup()
+}
+
+func (r *logTokenRepo) teardown() (err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			logFieldDuration, time.Since(begin).Nanoseconds(),
+			logFieldOp, "teardown",
+		}
+
+		if err != nil {
+			ps = append(ps, logFieldErr, err)
+		}
+
+		_ = r.logger.Log(ps...)
+	}(time.Now())
+
+	return r.next.teardown()
+}

--- a/pkg/client/middleware.go
+++ b/pkg/client/middleware.go
@@ -1,0 +1,42 @@
+package client
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/pkg/errors"
+)
+
+type contextKey string
+
+// Context keys.
+const (
+	ContextKeyClientID contextKey = "clientID"
+	contextKeySecret   contextKey = "clientSecret"
+)
+
+const (
+	secretLen     = 44
+	secretByteLen = 32
+)
+
+// AuthMiddleware returns a client token based authentication.
+func AuthMiddleware(svc Service) endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, request interface{}) (interface{}, error) {
+			secret, ok := ctx.Value(contextKeySecret).(string)
+			if !ok {
+				return nil, errors.Wrap(ErrSecretMissing, "request context")
+			}
+
+			c, err := svc.LookupBySecret(secret)
+			if err != nil {
+				return nil, errors.Wrap(err, "client lookup")
+			}
+
+			ctx = context.WithValue(ctx, ContextKeyClientID, c.id)
+
+			return next(ctx, request)
+		}
+	}
+}

--- a/pkg/client/middleware_test.go
+++ b/pkg/client/middleware_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/lifesum/configsum/pkg/generate"
+)
+
+func TestAuthMiddleware(t *testing.T) {
+	var (
+		repo      = prepareInmemRepo(t)
+		tokenRepo = prepareInmemTokenRepo(t)
+		svc       = NewService(repo, tokenRepo)
+
+		clientID   = generate.RandomString(24)
+		clientName = generate.RandomString(12)
+		secret     = generate.RandomString(32)
+	)
+
+	_, err := repo.Store(clientID, clientName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = tokenRepo.Store(clientID, secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.TODO()
+	ctx = context.WithValue(ctx, contextKeySecret, secret)
+
+	_, err = AuthMiddleware(svc)(nopEndpoint)(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAuthMiddlewareSecretMissing(t *testing.T) {
+	var (
+		repo      Repo
+		tokenRepo TokenRepo
+
+		svc = NewService(repo, tokenRepo)
+	)
+
+	ctx := context.TODO()
+
+	_, err := AuthMiddleware(svc)(nopEndpoint)(ctx, nil)
+	if have, want := errors.Cause(err), ErrSecretMissing; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func nopEndpoint(ctx context.Context, request interface{}) (interface{}, error) {
+	return true, nil
+}

--- a/pkg/client/postgres.go
+++ b/pkg/client/postgres.go
@@ -115,9 +115,9 @@ func (r *pgRepo) Lookup(id string) (Client, error) {
 
 			return r.Lookup(id)
 		case sql.ErrNoRows:
-			return Client{}, errors.Wrap(ErrNotFound, "config get")
+			return Client{}, errors.Wrap(ErrNotFound, "client lookup")
 		default:
-			return Client{}, errors.Wrap(err, "config get")
+			return Client{}, errors.Wrap(err, "client lookup")
 		}
 	}
 

--- a/pkg/client/postgres_test.go
+++ b/pkg/client/postgres_test.go
@@ -5,113 +5,30 @@ package client
 import (
 	"flag"
 	"fmt"
-	"math/rand"
 	"os/user"
 	"testing"
-	"time"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/oklog/ulid"
-	"github.com/pkg/errors"
 
-	"github.com/lifesum/configsum/pkg/generate"
 	"github.com/lifesum/configsum/pkg/pg"
 )
 
 var pgURI string
 
 func TestPGRepoLookup(t *testing.T) {
-	var (
-		name = generate.RandomString(24)
-		repo = preparePGRepo(t)
-		seed = rand.New(rand.NewSource(time.Now().UnixNano()))
-	)
-
-	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = repo.Store(id.String(), name)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	c, err := repo.Lookup(id.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if have, want := c.id, id.String(); have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-
-	if have, want := c.name, name; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-
-	if have, want := c.deleted, false; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
+	testRepoLookup(t, preparePGRepo)
 }
 
 func TestPGRepoLookupNotFound(t *testing.T) {
-	var (
-		id   = generate.RandomString(24)
-		repo = preparePGRepo(t)
-	)
-
-	_, err := repo.Lookup(id)
-	if have, want := errors.Cause(err), ErrNotFound; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
+	testRepoLookupNotFound(t, preparePGRepo)
 }
 
 func TestPGTokenRepoLookup(t *testing.T) {
-	var (
-		secret = generate.RandomString(32)
-		repo   = preparePGTokenRepo(t)
-		seed   = rand.New(rand.NewSource(time.Now().UnixNano()))
-	)
-
-	clientID, err := ulid.New(ulid.Timestamp(time.Now()), seed)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = repo.Store(clientID.String(), secret)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	token, err := repo.Lookup(secret)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if have, want := token.clientID, clientID.String(); have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-
-	if have, want := token.deleted, false; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-
-	if have, want := token.secret, secret; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
+	testTokenRepoLookup(t, preparePGTokenRepo)
 }
 
 func TestPGTokenRepoLookupNotFound(t *testing.T) {
-	var (
-		secret = generate.RandomString(32)
-		repo   = preparePGTokenRepo(t)
-	)
-
-	_, err := repo.Lookup(secret)
-	if have, want := errors.Cause(err), ErrNotFound; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
+	testTokenRepoLookupNotFound(t, preparePGTokenRepo)
 }
 
 func preparePGRepo(t *testing.T) Repo {

--- a/pkg/client/repo.go
+++ b/pkg/client/repo.go
@@ -19,6 +19,9 @@ type Repo interface {
 	Store(id, name string) (Client, error)
 }
 
+// RepoMiddleware is a chainable behaviour modifier for Repo.
+type RepoMiddleware func(Repo) Repo
+
 // TokenRepo for Token interactions.
 type TokenRepo interface {
 	lifecycle
@@ -26,6 +29,9 @@ type TokenRepo interface {
 	Lookup(secret string) (Token, error)
 	Store(clientID, secret string) (Token, error)
 }
+
+// TokenRepoMiddleware is a chainable behaviour modifier for TokenRepo.
+type TokenRepoMiddleware func(next TokenRepo) TokenRepo
 
 // Token is the relation between a Client secret and id.
 type Token struct {

--- a/pkg/client/repo_test.go
+++ b/pkg/client/repo_test.go
@@ -1,0 +1,116 @@
+package client
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+
+	"github.com/lifesum/configsum/pkg/generate"
+)
+
+type prepareRepoFunc func(t *testing.T) Repo
+
+func testRepoLookup(t *testing.T, p prepareRepoFunc) {
+	var (
+		name = generate.RandomString(24)
+		repo = p(t)
+		seed = rand.New(rand.NewSource(time.Now().UnixNano()))
+	)
+
+	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Store(id.String(), name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := repo.Lookup(id.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := c.id, id.String(); have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := c.name, name; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := c.deleted, false; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testRepoLookupNotFound(t *testing.T, p prepareRepoFunc) {
+	var (
+		id   = generate.RandomString(24)
+		repo = p(t)
+	)
+
+	_, err := repo.Lookup(id)
+	if have, want := errors.Cause(err), ErrNotFound; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+type prepareTokenRepoFunc func(t *testing.T) TokenRepo
+
+func testTokenRepoLookup(t *testing.T, p prepareTokenRepoFunc) {
+	var (
+		repo = p(t)
+		seed = rand.New(rand.NewSource(time.Now().UnixNano()))
+	)
+
+	secret, err := generate.SecureToken(secretByteLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientID, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Store(clientID.String(), secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := repo.Lookup(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := token.clientID, clientID.String(); have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := token.deleted, false; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := token.secret, secret; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testTokenRepoLookupNotFound(t *testing.T, p prepareTokenRepoFunc) {
+	repo := p(t)
+
+	secret, err := generate.SecureToken(secretByteLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Lookup(secret)
+	if have, want := errors.Cause(err), ErrNotFound; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}

--- a/pkg/client/service.go
+++ b/pkg/client/service.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Service provides Clients.
+type Service interface {
+	LookupBySecret(secret string) (Client, error)
+}
+
+type service struct {
+	repo      Repo
+	tokenRepo TokenRepo
+}
+
+// NewService provides Clients.
+func NewService(repo Repo, tokenRepo TokenRepo) Service {
+	return &service{
+		repo:      repo,
+		tokenRepo: tokenRepo,
+	}
+}
+
+func (s *service) LookupBySecret(secret string) (Client, error) {
+	t, err := s.tokenRepo.Lookup(secret)
+	if err != nil {
+		return Client{}, errors.Wrap(err, "service lookup")
+	}
+
+	return s.repo.Lookup(t.clientID)
+}

--- a/pkg/client/service_test.go
+++ b/pkg/client/service_test.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid"
+
+	"github.com/lifesum/configsum/pkg/generate"
+)
+
+func TestServiceLookupBySecret(t *testing.T) {
+	var (
+		repo      = prepareInmemRepo(t)
+		tokenRepo = prepareInmemTokenRepo(t)
+		seed      = rand.New(rand.NewSource(time.Now().UnixNano()))
+		svc       = NewService(repo, tokenRepo)
+	)
+
+	clientID, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secret, err := generate.SecureToken(secretByteLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := repo.Store(clientID.String(), generate.RandomString(12))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = tokenRepo.Store(c.id, secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = svc.LookupBySecret(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := c.id, clientID; err != nil {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"context"
+	"net/http"
+)
+
+const headerToken = "X-Configsum-Token"
+
+// HTTPToContext moves the Client secret token from request header to context.
+func HTTPToContext(
+	ctx context.Context,
+	r *http.Request,
+) context.Context {
+	secret := r.Header.Get(headerToken)
+	if len(secret) != secretLen {
+		return ctx
+	}
+
+	return context.WithValue(ctx, contextKeySecret, secret)
+}

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/lifesum/configsum/pkg/generate"
+)
+
+func TestHTTPToContext(t *testing.T) {
+	secret, err := generate.SecureToken(secretByteLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts := map[*http.Request]interface{}{
+		&http.Request{}: nil,
+		&http.Request{
+			Header: http.Header{
+				headerToken: []string{"invalidSecret"},
+			},
+		}: nil,
+		&http.Request{
+			Header: http.Header{
+				headerToken: []string{secret},
+			},
+		}: secret,
+	}
+
+	for r, want := range ts {
+		ctx := HTTPToContext(context.TODO(), r)
+
+		if have := ctx.Value(contextKeySecret); have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+	}
+
+}

--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/endpoint"
+
+	"github.com/lifesum/configsum/pkg/client"
 )
 
 type userRequest struct {
-	appID      string
 	baseConfig string
 }
 
@@ -24,9 +25,12 @@ func (r userResponse) StatusCode() int {
 
 func userEndpoint(svc ServiceUser) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(userRequest)
+		var (
+			req      = request.(userRequest)
+			clientID = ctx.Value(client.ContextKeyClientID).(string)
+		)
 
-		c, err := svc.Render(req.appID, req.baseConfig, "id123")
+		c, err := svc.Render(clientID, req.baseConfig, "id123")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -11,7 +11,7 @@ import (
 
 // ServiceUser provides user specific configs.
 type ServiceUser interface {
-	Render(appID, baseName, userID string) (UserConfig, error)
+	Render(clientID, baseName, userID string) (UserConfig, error)
 }
 
 type serviceUser struct {
@@ -29,8 +29,8 @@ func NewServiceUser(baseRepo BaseRepo, userRepo UserRepo) ServiceUser {
 	}
 }
 
-func (s *serviceUser) Render(appID, baseName, userID string) (UserConfig, error) {
-	bc, err := s.baseRepo.Get(appID, baseName)
+func (s *serviceUser) Render(clientID, baseName, userID string) (UserConfig, error) {
+	bc, err := s.baseRepo.Get(clientID, baseName)
 	if err != nil {
 		return UserConfig{}, errors.Wrap(err, "baseRepo.Get")
 	}

--- a/pkg/config/transport.go
+++ b/pkg/config/transport.go
@@ -2,24 +2,42 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/go-kit/kit/log"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+
+	"github.com/lifesum/configsum/pkg/client"
+)
+
+// Headers.
+const (
+	headerContentType = "Content-Type"
 )
 
 // MakeHandler returns an http.Handler for the config service.
-func MakeHandler(logger log.Logger, svc ServiceUser) http.Handler {
+func MakeHandler(
+	logger log.Logger,
+	svc ServiceUser,
+	clientSVC client.Service,
+) http.Handler {
 	r := mux.NewRouter()
 	r.StrictSlash(true)
 
 	r.Methods("PUT").Path(`/{baseConfig:[a-z0-9]+}`).Name("configUser").Handler(
 		kithttp.NewServer(
-			userEndpoint(svc),
+			client.AuthMiddleware(clientSVC)(
+				userEndpoint(svc),
+			),
 			decodeUserRequest,
 			kithttp.EncodeJSONResponse,
+			kithttp.ServerBefore(client.HTTPToContext),
+			kithttp.ServerErrorEncoder(encodeError),
+			kithttp.ServerErrorLogger(log.With(logger, "route", "configUser")),
 		),
 	)
 
@@ -31,5 +49,25 @@ func decodeUserRequest(ctx context.Context, r *http.Request) (interface{}, error
 	if !ok {
 		return nil, fmt.Errorf("Baseconfig missing")
 	}
+
 	return userRequest{baseConfig: c}, nil
+}
+
+func encodeError(_ context.Context, err error, w http.ResponseWriter) {
+	switch errors.Cause(err) {
+	case ErrNotFound:
+		w.WriteHeader(http.StatusNotFound)
+	case client.ErrNotFound, client.ErrSecretMissing:
+		w.WriteHeader(http.StatusUnauthorized)
+	default:
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	w.Header().Set(headerContentType, "application/json; charset=utf-8")
+
+	_ = json.NewEncoder(w).Encode(struct {
+		Reason string `json:"reason"`
+	}{
+		Reason: err.Error(),
+	})
 }

--- a/pkg/generate/rand.go
+++ b/pkg/generate/rand.go
@@ -1,9 +1,12 @@
 package generate
 
 import (
+	crand "crypto/rand"
 	"encoding/base64"
 	"math/rand"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ~!$%^&*()_+{}:\"|<>?`-=[];'\\,./"
@@ -34,6 +37,20 @@ func RandomString(n int) string {
 			n,
 		),
 	)
+}
+
+// SecureToken returns a securely generated random string.
+//
+// It will error if the system's secure random number generator fails.
+func SecureToken(n int) (string, error) {
+	b := make([]byte, n)
+
+	_, err := crand.Read(b)
+	if err != nil {
+		return "", errors.Wrap(err, "SecureToken")
+	}
+
+	return base64.URLEncoding.EncodeToString(b), nil
 }
 
 func randomBytes(src rand.Source, bytes string, n int) []byte {


### PR DESCRIPTION
After introducing Client with their Tokens we want to enable using these for secret based authentication, where the consumer sends the generated secret in the `X-Configsum-Token` custom header. In the middleware inspects the header checks for validity of the secret and lookups the corresponding Token to find the associated Client. Should one of these steps fail the middleware rejects the request and no following endpoint will be called.

We need a fully setup client to be present in order for the entity hierarchy of the config service to work properly. To acheive this we apply the AuthMiddleware exposed by the client package to guard against unathenticated calls and inject a proepr client identy in the call chain.

* public middleware
* client service
* HTTPToContext for lifting of the secret into the request context
* inmem implementations for client repos
* breaking out repo tests for re-use
* generate method for secure token generation
* client repo middleware
* token repo middleware
* instrument services
* logging services
* decorate user config handler with client auth middleware
* setup client repos in main
* setup client service in main
* pass service to config handler