### PR TITLE
Support initial base config state

### DIFF
--- a/pkg/config/inmem.go
+++ b/pkg/config/inmem.go
@@ -7,16 +7,17 @@ import (
 	"github.com/pkg/errors"
 )
 
-type inmemBaseState map[string]map[string]BaseConfig
+// InmemBaseState is a container to pass initial state for the inmem repo.
+type InmemBaseState map[string]map[string]BaseConfig
 
 type inmemBaseRepo struct {
-	configs inmemBaseState
+	configs InmemBaseState
 }
 
 // NewInmemBaseRepo returns an in-memory backed BaseRepo implementation.
-func NewInmemBaseRepo(initial inmemBaseState) (BaseRepo, error) {
+func NewInmemBaseRepo(initial InmemBaseState) (BaseRepo, error) {
 	if initial == nil {
-		initial = inmemBaseState{}
+		initial = InmemBaseState{}
 	}
 
 	return &inmemBaseRepo{

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -4,15 +4,15 @@ import "time"
 
 // BaseRepo provides access to base configs.
 type BaseRepo interface {
-	Get(appID, name string) (BaseConfig, error)
+	Get(clientID, name string) (BaseConfig, error)
 }
 
 // BaseConfig is the entire space of available parameters.
 type BaseConfig struct {
-	appID    string
-	id       string
-	name     string
-	rendered rendered
+	ClientID string
+	ID       string
+	Name     string
+	Rendered rendered
 }
 
 type rendered map[string]interface{}

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -35,7 +35,7 @@ func (s *serviceUser) Render(clientID, baseName, userID string) (UserConfig, err
 		return UserConfig{}, errors.Wrap(err, "baseRepo.Get")
 	}
 
-	uc, err := s.userRepo.GetLatest(bc.id, userID)
+	uc, err := s.userRepo.GetLatest(bc.ID, userID)
 	if err != nil {
 		switch errors.Cause(err) {
 		case ErrNotFound:
@@ -47,7 +47,7 @@ func (s *serviceUser) Render(clientID, baseName, userID string) (UserConfig, err
 
 	// TODO(nabilm): Create temp config with rules applied
 
-	if reflect.DeepEqual(bc.rendered, uc.rendered) {
+	if reflect.DeepEqual(bc.Rendered, uc.rendered) {
 		return uc, nil
 	}
 
@@ -56,5 +56,5 @@ func (s *serviceUser) Render(clientID, baseName, userID string) (UserConfig, err
 		return UserConfig{}, errors.Wrap(err, "create ulid")
 	}
 
-	return s.userRepo.Append(id.String(), bc.id, userID, nil, bc.rendered)
+	return s.userRepo.Append(id.String(), bc.ID, userID, nil, bc.Rendered)
 }

--- a/pkg/config/service_test.go
+++ b/pkg/config/service_test.go
@@ -9,19 +9,19 @@ import (
 
 func TestServiceUserRender(t *testing.T) {
 	var (
-		appID      = randString(characterSet)
+		clientID   = randString(characterSet)
 		baseID     = randString(characterSet)
 		baseName   = randString(characterSet)
 		baseRender = rendered{
 			randString(characterSet): false,
 		}
-		baseRepo, _ = NewInmemBaseRepo(inmemBaseState{
-			appID: map[string]BaseConfig{
+		baseRepo, _ = NewInmemBaseRepo(InmemBaseState{
+			clientID: map[string]BaseConfig{
 				baseName: BaseConfig{
-					appID:    appID,
-					id:       baseID,
-					name:     baseName,
-					rendered: baseRender,
+					ClientID: clientID,
+					ID:       baseID,
+					Name:     baseName,
+					Rendered: baseRender,
 				},
 			},
 		})
@@ -30,7 +30,7 @@ func TestServiceUserRender(t *testing.T) {
 		svc         = NewServiceUser(baseRepo, userRepo)
 	)
 
-	uc, err := svc.Render(appID, baseName, userID)
+	uc, err := svc.Render(clientID, baseName, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestServiceUserRender(t *testing.T) {
 		t.Errorf("have %#v,want %#v", have, want)
 	}
 
-	rc, err := svc.Render(appID, baseName, userID)
+	rc, err := svc.Render(clientID, baseName, userID)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Until we have proper integration with storage we want to be able to serve some simple form of base config that can be passed in from the outside.

* add `base.state` flag
* parse json state file
* pass initial state to base repo