### PR TITLE
Implement simple authentication

### DIFF
--- a/pkg/auth/simple/error.go
+++ b/pkg/auth/simple/error.go
@@ -1,0 +1,9 @@
+package simple
+
+import (
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrUserIDMissing = errors.New("userID missing")
+)

--- a/pkg/auth/simple/middleware.go
+++ b/pkg/auth/simple/middleware.go
@@ -1,0 +1,34 @@
+package simple
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/pkg/errors"
+
+	"github.com/lifesum/configsum/pkg/auth"
+)
+
+type contextKey string
+
+const (
+	contextKeyUserID contextKey = "simpleUserID"
+)
+
+// AuthMiddleware returns a pluggable endpoint.Middleware which rejects the
+// request if:
+// * userID is missing from the context
+func AuthMiddleware() endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, request interface{}) (interface{}, error) {
+			userID, ok := ctx.Value(contextKeyUserID).(string)
+			if !ok {
+				return nil, errors.Wrap(ErrUserIDMissing, "request context")
+			}
+
+			ctx = context.WithValue(ctx, auth.ContextKeyUserID, userID)
+
+			return next(ctx, request)
+		}
+	}
+}

--- a/pkg/auth/simple/middleware_test.go
+++ b/pkg/auth/simple/middleware_test.go
@@ -1,0 +1,46 @@
+package simple
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/pkg/errors"
+
+	"github.com/lifesum/configsum/pkg/auth"
+	"github.com/lifesum/configsum/pkg/generate"
+)
+
+func TestAuthMiddleware(t *testing.T) {
+	var (
+		userID = generate.RandomString(24)
+		ctx    = context.WithValue(context.TODO(), contextKeyUserID, userID)
+	)
+
+	_, err := AuthMiddleware()(nopEndpoint(t, userID))(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAuthMiddlewareUserIDMissing(t *testing.T) {
+	_, err := AuthMiddleware()(nopEndpoint(t, ""))(context.TODO(), nil)
+	if have, want := errors.Cause(err), ErrUserIDMissing; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func nopEndpoint(t *testing.T, want string) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		have, ok := ctx.Value(auth.ContextKeyUserID).(string)
+		if !ok {
+			t.Fatalf("userID missing")
+		}
+
+		if have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+
+		return true, nil
+	}
+}

--- a/pkg/auth/simple/transport.go
+++ b/pkg/auth/simple/transport.go
@@ -1,0 +1,20 @@
+package simple
+
+import (
+	"context"
+	"net/http"
+)
+
+const headerUserID = "X-Configsum-Userid"
+
+// HTTPToContext moves the userID from the X-Configsum-Userid header into the
+// context of the request.
+func HTTPToContext(ctx context.Context, r *http.Request) context.Context {
+	userID := r.Header.Get(headerUserID)
+
+	if userID == "" {
+		return ctx
+	}
+
+	return context.WithValue(ctx, contextKeyUserID, userID)
+}

--- a/pkg/auth/simple/transport_test.go
+++ b/pkg/auth/simple/transport_test.go
@@ -1,0 +1,31 @@
+package simple
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/lifesum/configsum/pkg/generate"
+)
+
+func TestHTTPToContext(t *testing.T) {
+	var (
+		userID = generate.RandomString(24)
+		ts     = map[*http.Request]interface{}{
+			&http.Request{}: nil,
+			&http.Request{
+				Header: http.Header{
+					headerUserID: []string{userID},
+				},
+			}: userID,
+		}
+	)
+
+	for r, want := range ts {
+		ctx := HTTPToContext(context.TODO(), r)
+
+		if have := ctx.Value(contextKeyUserID); have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+	}
+}


### PR DESCRIPTION
In environments, like local dev, where we don't have a fully functionalauthentication system we want to be able to provide the userID to interact with the system regardless. To achieve this we added a simple
authentication which expects `X-Configsum-Userid` and lifts it into the request context.

* add simple auth middleware
* add transport helper