### PR TITLE
Correct Dory hashing

### DIFF
--- a/pkg/auth/dory/middleware.go
+++ b/pkg/auth/dory/middleware.go
@@ -60,5 +60,10 @@ func hashSignature(secret, userID string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%x", h.Sum([]byte(userID))), nil
+	_, err = h.Write([]byte(userID))
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }


### PR DESCRIPTION
Instead of writing to the buffer we sumed prematurely which resulted in an incorrect signature.