### PR TITLE
Add shared framework schema for iOS platform

### DIFF
--- a/sdk/ios/Configsum/Configsum/Configsum.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/sdk/ios/Configsum/Configsum/Configsum.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:Configsum.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/sdk/ios/Configsum/Configsum/Configsum.xcodeproj/xcshareddata/xcschemes/Configsum.xcscheme
+++ b/sdk/ios/Configsum/Configsum/Configsum.xcodeproj/xcshareddata/xcschemes/Configsum.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3E298A011F852D00002F007B"
+               BuildableName = "Configsum.framework"
+               BlueprintName = "Configsum"
+               ReferencedContainer = "container:Configsum.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3E298A0A1F852D00002F007B"
+               BuildableName = "ConfigsumTests.xctest"
+               BlueprintName = "ConfigsumTests"
+               ReferencedContainer = "container:Configsum.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3E298A011F852D00002F007B"
+            BuildableName = "Configsum.framework"
+            BlueprintName = "Configsum"
+            ReferencedContainer = "container:Configsum.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3E298A011F852D00002F007B"
+            BuildableName = "Configsum.framework"
+            BlueprintName = "Configsum"
+            ReferencedContainer = "container:Configsum.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3E298A011F852D00002F007B"
+            BuildableName = "Configsum.framework"
+            BlueprintName = "Configsum"
+            ReferencedContainer = "container:Configsum.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
In order for Carthage to be able to build the framework Configsum needs to expose a shared framework schema for the desired platform