### PR TITLE
Allow dashes in config route

### DIFF
--- a/pkg/config/transport.go
+++ b/pkg/config/transport.go
@@ -46,7 +46,7 @@ func MakeHandler(
 		kithttp.ServerFinalizer(serverFinalizer(log.With(logger, "route", "configUser"))),
 	)
 
-	r.Methods("PUT").Path(`/{baseConfig:[a-z0-9]+}`).Name("configUser").Handler(
+	r.Methods("PUT").Path(`/{baseConfig:[a-z0-9\-]+}`).Name("configUser").Handler(
 		kithttp.NewServer(
 			auth(userEndpoint(svc)),
 			decodeUserRequest,


### PR DESCRIPTION
In order to build up more complex naming schemes for base_configs we add dash (`-`) as allowed character, additional to the already supported alphanumerics.