### PR TITLE
Remove traces of app

### DIFF
--- a/pkg/config/inmem.go
+++ b/pkg/config/inmem.go
@@ -25,13 +25,13 @@ func NewInmemBaseRepo(initial InmemBaseState) (BaseRepo, error) {
 	}, nil
 }
 
-func (s *inmemBaseRepo) Get(appID, name string) (BaseConfig, error) {
-	app, ok := s.configs[appID]
+func (s *inmemBaseRepo) Get(clientID, name string) (BaseConfig, error) {
+	client, ok := s.configs[clientID]
 	if !ok {
-		return BaseConfig{}, errors.Wrap(errors.ErrNotFound, fmt.Sprintf("app id '%s'", appID))
+		return BaseConfig{}, errors.Wrap(errors.ErrNotFound, fmt.Sprintf("client id '%s'", clientID))
 	}
 
-	bc, ok := app[name]
+	bc, ok := client[name]
 	if !ok {
 		return BaseConfig{}, errors.Wrap(errors.ErrNotFound, fmt.Sprintf("base config name '%s'", name))
 	}

--- a/pkg/config/service_test.go
+++ b/pkg/config/service_test.go
@@ -60,7 +60,7 @@ func TestServiceUserRender(t *testing.T) {
 
 func TestServiceUserRenderConfigMissingBaseConfig(t *testing.T) {
 	var (
-		appID       = randString(characterSet)
+		clientID    = randString(characterSet)
 		baseName    = randString(characterSet)
 		baseRepo, _ = NewInmemBaseRepo(nil)
 		userID      = randString(characterSet)
@@ -68,7 +68,7 @@ func TestServiceUserRenderConfigMissingBaseConfig(t *testing.T) {
 		svc         = NewServiceUser(baseRepo, userRepo)
 	)
 
-	_, err := svc.Render(appID, baseName, userID)
+	_, err := svc.Render(clientID, baseName, userID)
 	if have, want := errors.Cause(err), errors.ErrNotFound; have != want {
 		t.Errorf("have %v, want %v", have, want)
 	}

--- a/ui/src/Main.elm
+++ b/ui/src/Main.elm
@@ -4,7 +4,7 @@ import Html exposing (Html, div, footer, h1, text)
 import Html.Attributes exposing (class)
 import Navigation
 import Action exposing (Msg(..))
-import Page.Apps as Apps
+import Page.Clients as Clients
 import Page.Blank as Blank
 import Route exposing (Route, navigate)
 import Views.Page as Page
@@ -38,8 +38,8 @@ type alias Model =
 
 
 type Page
-    = Apps
-    | Blank String
+    = Blank String
+    | Clients
     | NotFound
 
 
@@ -82,7 +82,7 @@ update msg model =
                 route =
                     case maybeRoute of
                         Nothing ->
-                            Route.Apps
+                            Route.Clients
 
                         Just route ->
                             route
@@ -102,16 +102,16 @@ setRoute maybeRoute model =
         Nothing ->
             ( { model | pageState = Loaded NotFound }, Cmd.none )
 
-        Just (Route.Apps) ->
-            ( { model | pageState = Loaded Apps }, Cmd.none )
+        Just Route.Clients ->
+            ( { model | pageState = Loaded Clients }, Cmd.none )
 
-        Just (Route.Configs) ->
+        Just Route.Configs ->
             ( { model | pageState = Loaded (Blank "Configs") }, Cmd.none )
 
-        Just (Route.NotFound) ->
+        Just Route.NotFound ->
             ( { model | pageState = Loaded NotFound }, Cmd.none )
 
-        Just (Route.Rules) ->
+        Just Route.Rules ->
             ( { model | pageState = Loaded (Blank "Rules") }, Cmd.none )
 
 
@@ -145,8 +145,8 @@ viewPage isLoading page route =
             Page.frame isLoading route
     in
         case page of
-            Apps ->
-                Apps.view
+            Clients ->
+                Clients.view
                     |> frame
 
             Blank name ->

--- a/ui/src/Page/Clients.elm
+++ b/ui/src/Page/Clients.elm
@@ -1,4 +1,4 @@
-module Page.Apps exposing (view)
+module Page.Clients exposing (view)
 
 import Html exposing (Html, div, h1, text)
 import Html.Attributes exposing (class)
@@ -7,5 +7,5 @@ import Html.Attributes exposing (class)
 view : Html msg
 view =
     div [ class "page" ]
-        [ h1 [] [ text "Apps" ]
+        [ h1 [] [ text "Clients" ]
         ]

--- a/ui/src/Route.elm
+++ b/ui/src/Route.elm
@@ -7,7 +7,7 @@ import UrlParser exposing (Parser, map, oneOf, parsePath, s)
 
 
 type Route
-    = Apps
+    = Clients
     | Configs
     | NotFound
     | Rules
@@ -16,8 +16,8 @@ type Route
 routes : Parser (Route -> a) a
 routes =
     oneOf
-        [ map Apps (s "")
-        , map Apps (s "apps")
+        [ map Clients (s "")
+        , map Clients (s "clients")
         , map Configs (s "configs")
         , map Rules (s "rules")
         ]
@@ -28,8 +28,8 @@ routeToString route =
     let
         pieces =
             case route of
-                Apps ->
-                    [ "apps" ]
+                Clients ->
+                    [ "clients" ]
 
                 Configs ->
                     [ "configs" ]

--- a/ui/src/Views/Page.elm
+++ b/ui/src/Views/Page.elm
@@ -27,7 +27,7 @@ viewHeader route =
             ]
         , nav []
             [ ul []
-                [ navLink route Route.Apps [ text "apps" ]
+                [ navLink route Route.Clients [ text "clients" ]
                 , navLink route Route.Configs [ text "configs" ]
                 , navLink route Route.Rules [ text "rules" ]
                 ]


### PR DESCRIPTION
Originally the entity that represents a consumer of the system was called App, along the way we revisited that and ended up with Client as the canonical name. This change is for consistency and future expansion
of the Console to avoid confusion.