### PR TITLE
Make repo metrics reusable

### DIFF
--- a/pkg/client/instrument.go
+++ b/pkg/client/instrument.go
@@ -1,19 +1,20 @@
 package client
 
-import "time"
+import (
+	"time"
+
+	"github.com/lifesum/configsum/pkg/instrument"
+)
 
 const (
 	labelRepo      = "client"
 	labelRepoToken = "token"
 )
 
-type countFunc func(store, repo, op string)
-type observeFunc func(store, repo, op string, begin time.Time)
-
 type instrumentRepo struct {
-	errCount  countFunc
-	opCount   countFunc
-	opObserve observeFunc
+	errCount  instrument.CountRepoFunc
+	opCount   instrument.CountRepoFunc
+	opObserve instrument.ObserveRepoFunc
 	next      Repo
 	store     string
 }
@@ -21,9 +22,9 @@ type instrumentRepo struct {
 // NewRepoInstrumentMiddleware wraps the next Repo with Prometheus
 // instrumenation capabilities.
 func NewRepoInstrumentMiddleware(
-	errCount countFunc,
-	opCount countFunc,
-	opObserve observeFunc,
+	errCount instrument.CountRepoFunc,
+	opCount instrument.CountRepoFunc,
+	opObserve instrument.ObserveRepoFunc,
 	store string,
 ) RepoMiddleware {
 	return func(next Repo) Repo {
@@ -79,9 +80,9 @@ func (r *instrumentRepo) track(begin time.Time, err error, op string) {
 }
 
 type instrumentTokenRepo struct {
-	errCount  countFunc
-	opCount   countFunc
-	opObserve observeFunc
+	errCount  instrument.CountRepoFunc
+	opCount   instrument.CountRepoFunc
+	opObserve instrument.ObserveRepoFunc
 	next      TokenRepo
 	store     string
 }
@@ -89,9 +90,9 @@ type instrumentTokenRepo struct {
 // NewTokenRepoInstrumentMiddleware wraps the next TokenRepo with Prometheus
 // instrumenation capabilities.
 func NewTokenRepoInstrumentMiddleware(
-	errCount countFunc,
-	opCount countFunc,
-	opObserve observeFunc,
+	errCount instrument.CountRepoFunc,
+	opCount instrument.CountRepoFunc,
+	opObserve instrument.ObserveRepoFunc,
 	store string,
 ) TokenRepoMiddleware {
 	return func(next TokenRepo) TokenRepo {

--- a/pkg/config/instrument.go
+++ b/pkg/config/instrument.go
@@ -2,17 +2,16 @@ package config
 
 import (
 	"time"
+
+	"github.com/lifesum/configsum/pkg/instrument"
 )
 
 const labelRepoUser = "user"
 
-type countFunc func(store, repo, op string)
-type observeFunc func(store, repo, op string, begin time.Time)
-
 type instrumentUserRepo struct {
-	errCount  countFunc
-	opCount   countFunc
-	opObserve observeFunc
+	errCount  instrument.CountRepoFunc
+	opCount   instrument.CountRepoFunc
+	opObserve instrument.ObserveRepoFunc
 	next      UserRepo
 	store     string
 }
@@ -20,9 +19,9 @@ type instrumentUserRepo struct {
 // NewUserRepoInstrumentMiddleware wraps the next UserRepo Prometheus
 // instrumentation capabilities.
 func NewUserRepoInstrumentMiddleware(
-	errCount countFunc,
-	opCount countFunc,
-	opObserve observeFunc,
+	errCount instrument.CountRepoFunc,
+	opCount instrument.CountRepoFunc,
+	opObserve instrument.ObserveRepoFunc,
 	store string,
 ) UserRepoMiddleware {
 	return func(next UserRepo) UserRepo {

--- a/pkg/instrument/intrument.go
+++ b/pkg/instrument/intrument.go
@@ -1,0 +1,9 @@
+package instrument
+
+import "time"
+
+// CountRepoFunc wraps a counter to track vital repo information.
+type CountRepoFunc func(store, repo, op string)
+
+// ObserveRepoFunc wraps a histogram to track repo op latencies.
+type ObserveRepoFunc func(store, repo, op string, begin time.Time)


### PR DESCRIPTION
In the same fashion as the rest of the supporting code in our cmd directory we break out the metrics for repos so we can re-use them in other sub-commands, along the way we introduce the `instrument` package which holds generally applicable types and helper.

* move repo metrics into helper function
* introduce instrument pkg
* pass instrument function types to implementations