### PR TITLE
Add metrics for http request

### DIFF
--- a/cmd/configsum/config.go
+++ b/cmd/configsum/config.go
@@ -171,12 +171,14 @@ func runConfig(args []string, logger log.Logger) error {
 		fmt.Sprintf(`%s/`, prefixConfig),
 		http.StripPrefix(
 			prefixConfig,
-			config.MakeHandler(logger,
+			config.MakeHandler(
+				logger,
 				svc,
 				auth,
 				requestCount,
 				requestLatency,
-				opts...),
+				opts...,
+			),
 		),
 	)
 

--- a/cmd/configsum/config.go
+++ b/cmd/configsum/config.go
@@ -62,6 +62,7 @@ func runConfig(args []string, logger log.Logger) error {
 	}(logger, *intrumentAddr)
 
 	repoErrCountFunc, repoOpCountFunc, repoOpLatencyFunc := metricsRepo()
+	requestCount, requestLatency := metricsRequest()
 
 	logger = log.With(logger, logService, serviceAPI)
 
@@ -170,7 +171,12 @@ func runConfig(args []string, logger log.Logger) error {
 		fmt.Sprintf(`%s/`, prefixConfig),
 		http.StripPrefix(
 			prefixConfig,
-			config.MakeHandler(logger, svc, auth, opts...),
+			config.MakeHandler(logger,
+				svc,
+				auth,
+				requestCount,
+				requestLatency,
+				opts...),
 		),
 	)
 

--- a/pkg/instrument/intrument.go
+++ b/pkg/instrument/intrument.go
@@ -7,3 +7,9 @@ type CountRepoFunc func(store, repo, op string)
 
 // ObserveRepoFunc wraps a histogram to track repo op latencies.
 type ObserveRepoFunc func(store, repo, op string, begin time.Time)
+
+// CountRequestFunc wraps a counter to track number of received requests.
+type CountRequestFunc func(host, method, statusCode string)
+
+// ObserveRequestFunc wraps a histogram to track request latencies.
+type ObserveRequestFunc func(host, method, statusCode string, begin time.Time)

--- a/pkg/instrument/intrument.go
+++ b/pkg/instrument/intrument.go
@@ -9,7 +9,7 @@ type CountRepoFunc func(store, repo, op string)
 type ObserveRepoFunc func(store, repo, op string, begin time.Time)
 
 // CountRequestFunc wraps a counter to track number of received requests.
-type CountRequestFunc func(host, method, statusCode string)
+type CountRequestFunc func(statusCode int, host, method, proto string)
 
 // ObserveRequestFunc wraps a histogram to track request latencies.
-type ObserveRequestFunc func(host, method, statusCode string, begin time.Time)
+type ObserveRequestFunc func(statusCode int, host, method, proto string, begin time.Time)


### PR DESCRIPTION
This iteration adds Prometheus metrics to the http request in the form of number of requests received and the latency of each request