### PR TITLE
Simplify metric collection

### DIFF
--- a/pkg/instrument/intrument.go
+++ b/pkg/instrument/intrument.go
@@ -1,15 +1,105 @@
 package instrument
 
-import "time"
+import (
+	"fmt"
+	"strconv"
+	"time"
 
-// CountRepoFunc wraps a counter to track vital repo information.
-type CountRepoFunc func(store, repo, op string)
+	kitprom "github.com/go-kit/kit/metrics/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/lifesum/configsum/pkg/errors"
+)
+
+// Labels.
+const (
+	labelErr        = "err"
+	labelHost       = "host"
+	labelMethod     = "method"
+	labelOp         = "op"
+	labelProto      = "proto"
+	labelRepo       = "repo"
+	labelStatusCode = "statusCode"
+	labelStore      = "store"
+)
+
+var (
+	repoLatencies    = map[string]*kitprom.Histogram{}
+	requestLatencies = map[string]*kitprom.Histogram{}
+)
 
 // ObserveRepoFunc wraps a histogram to track repo op latencies.
-type ObserveRepoFunc func(store, repo, op string, begin time.Time)
+type ObserveRepoFunc func(store, repo, op string, begin time.Time, err error)
 
-// CountRequestFunc wraps a counter to track number of received requests.
-type CountRequestFunc func(statusCode int, host, method, proto string)
+// ObserveRepo wraps a histogram to track repo op latencies.
+func ObserveRepo(namespace, subsystem string) ObserveRepoFunc {
+	key := fmt.Sprintf("%s-%s", namespace, subsystem)
+
+	_, ok := repoLatencies[key]
+	if !ok {
+		repoLatencies[key] = kitprom.NewHistogramFrom(
+			prometheus.HistogramOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "op_latency_seconds",
+				Help:      "Latency of repo operations.",
+			},
+			[]string{
+				labelErr,
+				labelOp,
+				labelRepo,
+				labelStore,
+			},
+		)
+	}
+
+	return func(store, repo, op string, begin time.Time, err error) {
+		errVal := ""
+
+		if e := errors.Cause(err); e != nil {
+			errVal = e.Error()
+		}
+
+		repoLatencies[key].With(
+			labelErr, errVal,
+			labelOp, op,
+			labelRepo, repo,
+			labelStore, store,
+		).Observe(time.Since(begin).Seconds())
+	}
+}
 
 // ObserveRequestFunc wraps a histogram to track request latencies.
-type ObserveRequestFunc func(statusCode int, host, method, proto string, begin time.Time)
+type ObserveRequestFunc func(code int, host, method, proto string, begin time.Time)
+
+// ObserveRequest wraps a histogram to track request latencies.
+func ObserveRequest(namespace, subsystem string) ObserveRequestFunc {
+	key := fmt.Sprintf("%s-%s", namespace, subsystem)
+
+	_, ok := requestLatencies[key]
+	if !ok {
+		requestLatencies[key] = kitprom.NewHistogramFrom(
+			prometheus.HistogramOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "transport_http_latency_seconds",
+				Help:      "Total duration of requests in seconds",
+			},
+			[]string{
+				labelHost,
+				labelMethod,
+				labelProto,
+				labelStatusCode,
+			},
+		)
+	}
+
+	return func(code int, host, method, proto string, begin time.Time) {
+		requestLatencies[key].With(
+			labelStatusCode, strconv.Itoa(code),
+			labelHost, host,
+			labelMethod, method,
+			labelProto, proto,
+		).Observe(time.Since(begin).Seconds())
+	}
+}


### PR DESCRIPTION
Turns out all relevant information can be expressed on a single histogram as those produce also `_count` timeseries which function as a counter and makes distinct counters obselete if we track the same dimensions anyway. While reducing the surface this change also bundles most concerns of instrumentation in the package itself, so that the cmd code has less knowledge about it.

* bundle metrics collection in histograms
* move metrics related code to package
* update instrumentation implementations