### PR TITLE
Add JSON schema validation for payloads

### DIFF
--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -2,8 +2,6 @@ package config
 
 import "github.com/xeipuuv/gojsonschema"
 
-var decodeClientPayloadSchema *gojsonschema.Schema
-
 const requestCapabilities = `
 {
 	  "$schema": "http://json-schema.org/draft-06/schema#",
@@ -94,6 +92,8 @@ const requestCapabilities = `
 	  },
 	  "required": ["app", "device"]
 }`
+
+var decodeClientPayloadSchema *gojsonschema.Schema
 
 func init() {
 	var err error

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -1,0 +1,105 @@
+package config
+
+import "github.com/xeipuuv/gojsonschema"
+
+var decodeClientPayloadSchema *gojsonschema.Schema
+
+const requestCapabilities = `
+{
+	  "$schema": "http://json-schema.org/draft-06/schema#",
+	  "title": "Client payload",
+	  "description": "Common set of information to determine device capabilities and user provided info.",
+	  "type": "object",
+	  "properties": {
+	  	"app": {
+	  		"type": "object",
+	  		"properties": {
+	  			"version": {
+	  				"description": "The version of the client application.",
+	  				"type": "string"
+	  			}
+	  		},
+	  		"required": ["version"]
+	  	},
+	    "metadata": {
+	      "type": "object",
+	      "additionalProperties": {
+	        "anyOf": [
+	          {
+	            "type": "string"
+	          },
+	          {
+	            "type": "integer"
+	          },
+	          {
+	            "type": "array",
+	            "items": {
+	              "type": "string"
+	            }
+	          },
+	          {
+	            "type": "array",
+	            "items": {
+	              "type": "integer"
+	            }
+	          }
+	        ]
+	      }
+	    },
+	    "device": {
+	    	"type": "object",
+	    	"properties": {
+	    		"location": {
+	    			"type": "object",
+	    			"properties": {
+	    				"locale": {
+	    					"description": "The device's locale setting according to ISO 639-3 and/or BCP 47.",
+	    					"type": "string",
+	    					"pattern": "^[a-z]{2,3}_([A-Z]{2}|[0-9]{3})$"
+	    				},
+	    				"timezoneOffset": {
+	    					"description": "time offset from GMT",
+	    					"type": "integer"
+	    				}
+	    			},
+	    			"required": ["locale", "timezoneOffset"]
+	    		},
+	    		"os": {
+	    			"type": "object",
+	    			"properties": {
+	    				"platform": {
+	    					"description": "The client platform that makes this request.",
+	    					"enum": [ "Android", "iOS", "WatchOS" ]
+	    				},
+	    				"version": {
+	    					"description": "Version of the os that runs on the client platform",
+	    					"type": "string"
+	    				}
+	    			},
+	    			"required": ["platform", "version"]
+	    		}
+	    	},
+	    	"required": ["location", "os"]
+	    },
+	    "user": {
+	    	"type": "object",
+	    	"properties": {
+	    		"age": {
+	    			"description": "Age of the application's logged in user.",
+	    			"type": "integer"
+	    		}
+	    	},
+	    	"required": ["age"]
+	    }
+	  },
+	  "required": ["app", "device"]
+}`
+
+func init() {
+	var err error
+
+	decodeClientPayloadSchema, err = gojsonschema.NewSchema(gojsonschema.NewStringLoader(requestCapabilities))
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/config/schema_test.go
+++ b/pkg/config/schema_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+var (
+	schema            = gojsonschema.NewStringLoader(requestCapabilities)
+	testFailingInputs = []string{
+		`{}`,                                                                                                                                                                   // App missing
+		`{"app": {}}`,                                                                                                                                                          // Empty App object
+		`{"app": {"version": "6.4.1"}}`,                                                                                                                                        // Device missing
+		`{"app": {"version": "6.4.1"}, "device": {}, "os": {"platform": "WatchOS", "version": "9.4"}}`,                                                                         // Empty Device object
+		`{"app": {"version": "6.4.1"}, "device": {"location": {}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,                                                           // Empty Location object
+		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB"}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,                                          // TimezoneOffset missing
+		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}}}`,                                                                   // OS missing
+		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}, "os": {}}}`,                                                         // Empty Os object
+		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}, "os": {"platform": "WatchOS"}}}`,                                    // Version missing
+		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "testLocale", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,             // Wrong locale format
+		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "testLocale", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {}}`, // Empty User object
+	}
+	testSuccessInputs = []string{
+		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {"age": 23}}`, // Working case
+	}
+)
+
+func TestPayloadValidationFailure(t *testing.T) {
+	want := "invalid JSON error"
+
+	for _, input := range testFailingInputs {
+		json := gojsonschema.NewStringLoader(input)
+
+		result, err := gojsonschema.Validate(schema, json)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if result.Valid() {
+			t.Errorf("have %v, want %v", input, want)
+		}
+	}
+}
+
+func TestPayloadValidationSuccess(t *testing.T) {
+	want := "valid JSON input"
+
+	for _, input := range testSuccessInputs {
+		json := gojsonschema.NewStringLoader(input)
+
+		result, err := gojsonschema.Validate(schema, json)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !result.Valid() {
+			t.Errorf("have %v, want %v", input, want)
+		}
+	}
+}

--- a/pkg/config/transport.go
+++ b/pkg/config/transport.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/go-kit/kit/log"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
+	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/lifesum/configsum/pkg/errors"
 	"github.com/lifesum/configsum/pkg/instrument"
@@ -63,7 +66,7 @@ func MakeHandler(
 	r.Methods("PUT").Path(`/{baseConfig:[a-z0-9\-]+}`).Name("configUser").Handler(
 		kithttp.NewServer(
 			auth(userEndpoint(svc)),
-			decodeUserRequest,
+			decodeJSONSchema(decodeUserRequest, decodeClientPayloadSchema),
 			encodeUserResponse,
 			opts...,
 		),
@@ -83,6 +86,40 @@ func populateRequestContext(ctx context.Context, r *http.Request) context.Contex
 	ctx = context.WithValue(ctx, ctxKeyRoute, route)
 
 	return ctx
+}
+
+func decodeJSONSchema(
+	next kithttp.DecodeRequestFunc,
+	schema *gojsonschema.Schema,
+) kithttp.DecodeRequestFunc {
+	return func(ctx context.Context, r *http.Request) (interface{}, error) {
+		raw, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(raw) == 0 {
+			return nil, errors.Wrap(errors.ErrInvalidPayload, "empty body")
+		}
+		res, err := schema.Validate(gojsonschema.NewBytesLoader(raw))
+		if nil != err {
+			return nil, errors.Wrap(errors.ErrInvalidPayload, err.Error())
+		}
+
+		if !res.Valid() {
+			err := errors.ErrInvalidPayload
+
+			for _, e := range res.Errors() {
+				err = errors.Wrap(err, e.String())
+			}
+
+			return nil, err
+		}
+
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(raw))
+
+		return next(ctx, r)
+	}
 }
 
 func decodeUserRequest(ctx context.Context, r *http.Request) (interface{}, error) {

--- a/pkg/config/transport_test.go
+++ b/pkg/config/transport_test.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/lifesum/configsum/pkg/errors"
+)
+
+const (
+	testSchema = `
+	{
+		  "$schema": "http://json-schema.org/draft-06/schema#",
+		  "title": "Client payload",
+		  "description": "Common set of information to determine device capabilities and user provided info.",
+		  "type": "object",
+		  "properties": {
+		  	"app": {
+		  		"type": "object",
+		  		"properties": {
+		  			"version": {
+		  				"description": "The version of the client application.",
+		  				"type": "string"
+		  			}
+		  		},
+		  		"required": ["version"]
+		  	},
+		    "metadata": {
+		      "type": "object",
+		      "additionalProperties": {
+		        "anyOf": [
+		          {
+		            "type": "string"
+		          },
+		          {
+		            "type": "integer"
+		          },
+		          {
+		            "type": "array",
+		            "items": {
+		              "type": "string"
+		            }
+		          },
+		          {
+		            "type": "array",
+		            "items": {
+		              "type": "integer"
+		            }
+		          }
+		        ]
+		      }
+		    },
+		    "device": {
+		    	"type": "object",
+		    	"properties": {
+		    		"location": {
+		    			"type": "object",
+		    			"properties": {
+		    				"locale": {
+		    					"description": "The device's locale setting according to ISO 639-3 and/or BCP 47.",
+		    					"type": "string",
+		    					"pattern": "^[a-z]{2,3}_([A-Z]{2}|[0-9]{3})$"
+		    				},
+		    				"timezoneOffset": {
+		    					"description": "time offset from GMT",
+		    					"type": "integer"
+		    				}
+		    			},
+		    			"required": ["locale", "timezoneOffset"]
+		    		},
+		    		"os": {
+		    			"type": "object",
+		    			"properties": {
+		    				"platform": {
+		    					"description": "The client platform that makes this request.",
+		    					"enum": [ "Android", "iOS", "WatchOS" ]
+		    				},
+		    				"version": {
+		    					"description": "Version of the os that runs on the client platform",
+		    					"type": "string"
+		    				}
+		    			},
+		    			"required": ["platform", "version"]
+		    		}
+		    	},
+		    	"required": ["location", "os"]
+		    },
+		    "user": {
+		    	"type": "object",
+		    	"properties": {
+		    		"age": {
+		    			"description": "Age of the application's logged in user.",
+		    			"type": "integer"
+		    		}
+		    	},
+		    	"required": ["age"]
+		    }
+		  },
+		  "required": ["app", "device"]
+	}`
+
+	failingSchema = `
+	{
+		  "$schema": "http://json-schema.org/draft-06/schema#",
+		  "title": "Client payload",
+		  "description": "Common set of information to determine device capabilities and user provided info.",
+		  "type": "object",
+		  "properties": {
+		  	"app": {
+		  		"type": "object",
+		  		"properties": {
+		  			"version": {
+		  				"description": "The version of the client application.",
+		  				"type": "string"
+		  			}
+		  		},
+		  		"required": ["version"]
+		  	}
+		  },
+		  "required": ["app"]
+	}`
+)
+
+var testInputs = []string{
+	`{}`,                                                                                                                                                                   // App missing
+	`{"app": {}}`,                                                                                                                                                          // Empty App object
+	`{"app": {"version": "6.4.1"}}`,                                                                                                                                        // Device missing
+	`{"app": {"version": "6.4.1"}, "device": {}, "os": {"platform": "WatchOS", "version": "9.4"}}`,                                                                         // Empty Device object
+	`{"app": {"version": "6.4.1"}, "device": {"location": {}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,                                                           // Empty Location object
+	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB"}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,                                          // TimezoneOffset missing
+	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}}}`,                                                                   // OS missing
+	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}, "os": {}}}`,                                                         // Empty Os object
+	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}, "os": {"platform": "WatchOS"}}}`,                                    // Version missing
+	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "testLocale", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,             // Wrong locale format
+	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "testLocale", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {}}`, // Empty User object
+}
+
+func TestPayloadValidation(t *testing.T) {
+
+	schema := gojsonschema.NewStringLoader(testSchema)
+
+	var (
+		want = "invalid JSON error"
+	)
+
+	for _, input := range testInputs {
+		json := gojsonschema.NewStringLoader(input)
+
+		result, err := gojsonschema.Validate(schema, json)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if result.Valid() {
+			t.Errorf("have %v, want %v", input, want)
+		}
+	}
+}
+
+func TestDecodeJSONSchemaEmptyBody(t *testing.T) {
+
+	var (
+		next = func(ctx context.Context, r *http.Request) (interface{}, error) {
+			return nil, nil
+		}
+		req = httptest.NewRequest("PUT", "/v1/config/foo", nil)
+	)
+
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(failingSchema))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, have := decodeJSONSchema(next, schema)(context.Background(), req)
+	if want := errors.ErrInvalidPayload; errors.Cause(have) != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func TestDecodeJSONSchemaMissingField(t *testing.T) {
+	var (
+		next = func(ctx context.Context, r *http.Request) (interface{}, error) {
+			return nil, nil
+		}
+		payload = bytes.NewBufferString(`{"platform": "WatchOS"}`)
+		req     = httptest.NewRequest("PUT", "/v1/config/foo", payload)
+	)
+
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(testSchema))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, have := decodeJSONSchema(next, schema)(context.Background(), req)
+	if want := errors.ErrInvalidPayload; errors.Cause(have) != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}

--- a/pkg/config/transport_test.go
+++ b/pkg/config/transport_test.go
@@ -29,141 +29,33 @@ const (
 		  			}
 		  		},
 		  		"required": ["version"]
-		  	},
-		    "metadata": {
-		      "type": "object",
-		      "additionalProperties": {
-		        "anyOf": [
-		          {
-		            "type": "string"
-		          },
-		          {
-		            "type": "integer"
-		          },
-		          {
-		            "type": "array",
-		            "items": {
-		              "type": "string"
-		            }
-		          },
-		          {
-		            "type": "array",
-		            "items": {
-		              "type": "integer"
-		            }
-		          }
-		        ]
-		      }
-		    },
-		    "device": {
-		    	"type": "object",
-		    	"properties": {
-		    		"location": {
-		    			"type": "object",
-		    			"properties": {
-		    				"locale": {
-		    					"description": "The device's locale setting according to ISO 639-3 and/or BCP 47.",
-		    					"type": "string",
-		    					"pattern": "^[a-z]{2,3}_([A-Z]{2}|[0-9]{3})$"
-		    				},
-		    				"timezoneOffset": {
-		    					"description": "time offset from GMT",
-		    					"type": "integer"
-		    				}
-		    			},
-		    			"required": ["locale", "timezoneOffset"]
-		    		},
-		    		"os": {
-		    			"type": "object",
-		    			"properties": {
-		    				"platform": {
-		    					"description": "The client platform that makes this request.",
-		    					"enum": [ "Android", "iOS", "WatchOS" ]
-		    				},
-		    				"version": {
-		    					"description": "Version of the os that runs on the client platform",
-		    					"type": "string"
-		    				}
-		    			},
-		    			"required": ["platform", "version"]
-		    		}
-		    	},
-		    	"required": ["location", "os"]
-		    },
-		    "user": {
-		    	"type": "object",
-		    	"properties": {
-		    		"age": {
-		    			"description": "Age of the application's logged in user.",
-		    			"type": "integer"
-		    		}
-		    	},
-		    	"required": ["age"]
-		    }
-		  },
-		  "required": ["app", "device"]
-	}`
-
-	failingSchema = `
-	{
-		  "$schema": "http://json-schema.org/draft-06/schema#",
-		  "title": "Client payload",
-		  "description": "Common set of information to determine device capabilities and user provided info.",
-		  "type": "object",
-		  "properties": {
-		  	"app": {
-		  		"type": "object",
-		  		"properties": {
-		  			"version": {
-		  				"description": "The version of the client application.",
-		  				"type": "string"
-		  			}
-		  		},
-		  		"required": ["version"]
 		  	}
 		  },
 		  "required": ["app"]
 	}`
 )
 
-var testInputs = []string{
-	`{}`,                                                                                                                                                                   // App missing
-	`{"app": {}}`,                                                                                                                                                          // Empty App object
-	`{"app": {"version": "6.4.1"}}`,                                                                                                                                        // Device missing
-	`{"app": {"version": "6.4.1"}, "device": {}, "os": {"platform": "WatchOS", "version": "9.4"}}`,                                                                         // Empty Device object
-	`{"app": {"version": "6.4.1"}, "device": {"location": {}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,                                                           // Empty Location object
-	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB"}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,                                          // TimezoneOffset missing
-	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}}}`,                                                                   // OS missing
-	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}, "os": {}}}`,                                                         // Empty Os object
-	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}, "os": {"platform": "WatchOS"}}}`,                                    // Version missing
-	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "testLocale", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,             // Wrong locale format
-	`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "testLocale", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {}}`, // Empty User object
-}
-
-func TestPayloadValidation(t *testing.T) {
-
-	schema := gojsonschema.NewStringLoader(testSchema)
-
+func TestDecodeJSONSchemaValidInput(t *testing.T) {
 	var (
-		want = "invalid JSON error"
+		next = func(ctx context.Context, r *http.Request) (interface{}, error) {
+			return true, nil
+		}
+		payload = bytes.NewBufferString(`{"app": {"version": "6.4.1"}}`)
+		req     = httptest.NewRequest("PUT", "/v1/config/foo", payload)
 	)
 
-	for _, input := range testInputs {
-		json := gojsonschema.NewStringLoader(input)
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(testSchema))
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		result, err := gojsonschema.Validate(schema, json)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if result.Valid() {
-			t.Errorf("have %v, want %v", input, want)
-		}
+	have, _ := decodeJSONSchema(next, schema)(context.Background(), req)
+	if want := true; have != want {
+		t.Errorf("have %v, want %v", have, want)
 	}
 }
 
 func TestDecodeJSONSchemaEmptyBody(t *testing.T) {
-
 	var (
 		next = func(ctx context.Context, r *http.Request) (interface{}, error) {
 			return nil, nil
@@ -171,7 +63,7 @@ func TestDecodeJSONSchemaEmptyBody(t *testing.T) {
 		req = httptest.NewRequest("PUT", "/v1/config/foo", nil)
 	)
 
-	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(failingSchema))
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(testSchema))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -19,6 +19,11 @@ var (
 	ErrUserIDMissing      = errors.New("userID missing")
 )
 
+// Transport errors.
+var (
+	ErrInvalidPayload = errors.New("payload invalid")
+)
+
 // Cause is a wraper over github.com/pkg/errors.Cause.
 func Cause(err error) error {
 	return errors.Cause(err)


### PR DESCRIPTION
Given the fairly complicated JSON payload we expect form clients due to various degrees of flexibility we offer a schema validation was put in place to offer certain restrictions on value types as well as nested objects

* tests for schema validation