### PR TITLE
Add index for GetLatest query

### DIFF
--- a/pkg/config/postgres.go
+++ b/pkg/config/postgres.go
@@ -47,6 +47,12 @@ const (
 			created_at DESC
 		LIMIT
 			1`
+
+	pgUserIndexGetLatest = `
+		CREATE INDEX
+			users_get_latest
+		ON
+			config.users(base_id, user_id, created_at DESC)`
 )
 
 type pgUserRepo struct {
@@ -167,6 +173,7 @@ func (r *pgUserRepo) Setup() error {
 	for _, q := range []string{
 		pgUserCreateSchema,
 		pgUserCreateTable,
+		pgUserIndexGetLatest,
 	} {
 		_, err := r.db.Exec(q)
 		if err != nil {


### PR DESCRIPTION
In order to have the lookup for the latest config of a user efficient we need to cover this common query with an index.