### PR TITLE
Extend sdk api to retrieve raw config

### DIFF
--- a/sdk/ios/Configsum/Configsum.swift
+++ b/sdk/ios/Configsum/Configsum.swift
@@ -95,4 +95,11 @@ public struct Configsum {
                                       success: success,
                                       failure: failure)
     }
+    
+    /// Returns the entire stored config
+    ///
+    /// - Returns: the config in the form for a key-value data structure
+    public func getRawConfig() -> [String: Any]? {
+        return dispatcher.retrieveRawConfig()
+    }
 }

--- a/sdk/ios/Configsum/Configuration/Environment.swift
+++ b/sdk/ios/Configsum/Configuration/Environment.swift
@@ -13,6 +13,7 @@ public struct Environment {
     public let baseConfigurationName: String
     public let hostName: String
     public let port: Int?
+    public let urlScheme: String
     
     /// Allows for custom environment
     ///
@@ -23,18 +24,21 @@ public struct Environment {
     ///   - baseConfigurationName: name for the base configuration
     ///   - hostName: host endpoint
     ///   - port: optional attribute for http/https requests
+    ///   - urlScheme: The scheme subcomponent of the URL. if not set it defaults to https
     public init(log: Bool,
                 token: String,
                 headers: [String: [String]],
                 baseConfigurationName: String,
                 hostName: String,
-                port: Int? = nil) {
+                port: Int? = nil,
+                urlScheme: String = "https") {
         self.log = log
         self.token = token
         self.headers = headers
         self.baseConfigurationName = baseConfigurationName
         self.hostName = hostName
         self.port = port
+        self.urlScheme = urlScheme
     }
     
     internal var serviceVersion: String {

--- a/sdk/ios/Configsum/Networking/Dispatcher.swift
+++ b/sdk/ios/Configsum/Networking/Dispatcher.swift
@@ -33,4 +33,9 @@ internal struct Dispatcher {
                                      failure: failure)
         }
     }
+    
+    internal func retrieveRawConfig() -> [String: Any]? {
+        let resultHandler = ResultHandler<Any>(persistence: self.persistence)
+        return resultHandler.rawConfig()
+    }
 }

--- a/sdk/ios/Configsum/Networking/ResultHandler.swift
+++ b/sdk/ios/Configsum/Networking/ResultHandler.swift
@@ -59,4 +59,8 @@ internal struct ResultHandler<T> {
             failure?(error)
         }
     }
+    
+    internal func rawConfig() -> [String: Any]? {
+        return self.persistence.get()
+    }
 }

--- a/sdk/ios/Configsum/Networking/Router.swift
+++ b/sdk/ios/Configsum/Networking/Router.swift
@@ -17,7 +17,7 @@ internal struct Router {
     let environment: Environment
     private var requestURL: URL? {
         var components = URLComponents()
-        components.scheme = "https"
+        components.scheme = environment.urlScheme
         components.host = environment.hostName
         components.port = environment.port
         components.path = "/\(environment.serviceVersion)/config/\(environment.baseConfigurationName)"

--- a/sdk/ios/ConfigsumTests/ConfigsumTests.swift
+++ b/sdk/ios/ConfigsumTests/ConfigsumTests.swift
@@ -55,4 +55,9 @@ class ConfigsumTests: XCTestCase {
                                                    defaultValue: false)
         XCTAssertFalse(boolValue)
     }
+    
+    func testGetRawConfig() {
+        let rawConfig = self.configsum.getRawConfig()
+        XCTAssertNotNil(rawConfig)
+    }
 }

--- a/sdk/ios/ConfigsumTests/IntegrationTests.swift
+++ b/sdk/ios/ConfigsumTests/IntegrationTests.swift
@@ -14,10 +14,12 @@ class IntegrationTests: XCTestCase {
     override func setUp() {
         super.setUp()
         let environment = Environment(log: true,
-                                      token: "KX_PunWe37Xba0X0iHf1xJMjlfi4bcU2Xqq1rAX-qOM=",
-                                      headers: ["X-Configsum-Userid": ["testSequence"]],
+                                      token: "xCXbGXeG14GQjAPNfUKouaPJjRk68h5RAGia4wzyC1A=",
+                                      headers: ["X-Configsum-Userid": ["123"]],
                                       baseConfigurationName: "houston",
-                                      hostName: "config.svc.test3.playground.lifesum.com")
+                                      hostName: "localhost",
+                                      port: 8700,
+                                      urlScheme: "http")
         self.configsum = Configsum(environment: environment)
         self.attributes = Context(appVersion: "8.6.7",
                                      locale: "en_GB",
@@ -110,6 +112,19 @@ class IntegrationTests: XCTestCase {
         }, failure: { error in
             XCTFail("http call failed with error: \(error)")
         })
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+    
+    func testGetRawConfig() {
+        let exp = expectation(description: "testGetRawConfig")
+        self.configsum.render(attributes: self.attributes,
+                              success: {
+            let rawConfig = self.configsum.getRawConfig()
+            XCTAssertNotNil(rawConfig)
+            exp.fulfill()
+        }) { error in
+            XCTFail("http call failed with error: \(error)")
+        }
         waitForExpectations(timeout: 10.0, handler: nil)
     }
 }

--- a/sdk/ios/ConfigsumTests/contextWithComplexMetadata.json
+++ b/sdk/ios/ConfigsumTests/contextWithComplexMetadata.json
@@ -18,7 +18,7 @@
         },
         "location" : {
             "locale" : "en-US",
-            "timezoneOffset" : 7200
+            "timezoneOffset" : 3600
         }
     },
     "user" : {

--- a/sdk/ios/ConfigsumTests/contextWithMetadata.json
+++ b/sdk/ios/ConfigsumTests/contextWithMetadata.json
@@ -13,7 +13,7 @@
         },
         "location" : {
             "locale" : "en-US",
-            "timezoneOffset" : 7200
+            "timezoneOffset" : 3600
         }
     },
     "user" : {

--- a/sdk/ios/ConfigsumTests/contextWithoutMetadata.json
+++ b/sdk/ios/ConfigsumTests/contextWithoutMetadata.json
@@ -10,7 +10,7 @@
         },
         "location" : {
             "locale" : "en-US",
-            "timezoneOffset" : 7200
+            "timezoneOffset" : 3600
         }
     },
     "user" : {


### PR DESCRIPTION
This added functionality allows for different use cases of the current config such as event tracking, logging etc. This will allow for direct retrieval of latest config stored locally.

* extend Environment to allow apis to run on local server through http
* tests for added api