### PR TITLE
Observe route correctly

### DIFF
--- a/pkg/config/transport.go
+++ b/pkg/config/transport.go
@@ -137,9 +137,10 @@ func serverFinalizer(
 	return func(ctx context.Context, code int, r *http.Request) {
 		var (
 			begin  = ctx.Value(ctxKeyTimeBegin).(time.Time)
-			method = ctx.Value(ctxKeyRoute).(string)
+			method = ctx.Value(kithttp.ContextKeyRequestMethod).(string)
 			host   = ctx.Value(kithttp.ContextKeyRequestHost).(string)
 			proto  = ctx.Value(kithttp.ContextKeyRequestProto).(string)
+			route  = ctx.Value(ctxKeyRoute).(string)
 		)
 
 		_ = logger.Log(
@@ -148,7 +149,7 @@ func serverFinalizer(
 				"authorization":    ctx.Value(kithttp.ContextKeyRequestAuthorization),
 				"header":           r.Header,
 				"host":             host,
-				"method":           ctx.Value(kithttp.ContextKeyRequestMethod),
+				"method":           method,
 				"path":             ctx.Value(kithttp.ContextKeyRequestPath),
 				"proto":            proto,
 				"referer":          ctx.Value(kithttp.ContextKeyRequestReferer),
@@ -162,8 +163,9 @@ func serverFinalizer(
 				"size":       ctx.Value(kithttp.ContextKeyResponseSize).(int64),
 				"statusCode": code,
 			},
+			"route", route,
 		)
 
-		reqObserve(code, host, method, proto, begin)
+		reqObserve(code, host, method, proto, route, begin)
 	}
 }

--- a/pkg/instrument/intrument.go
+++ b/pkg/instrument/intrument.go
@@ -19,6 +19,7 @@ const (
 	labelOp         = "op"
 	labelProto      = "proto"
 	labelRepo       = "repo"
+	labelRoute      = "route"
 	labelStatusCode = "statusCode"
 	labelStore      = "store"
 )
@@ -70,7 +71,11 @@ func ObserveRepo(namespace, subsystem string) ObserveRepoFunc {
 }
 
 // ObserveRequestFunc wraps a histogram to track request latencies.
-type ObserveRequestFunc func(code int, host, method, proto string, begin time.Time)
+type ObserveRequestFunc func(
+	code int,
+	host, method, proto, route string,
+	begin time.Time,
+)
 
 // ObserveRequest wraps a histogram to track request latencies.
 func ObserveRequest(namespace, subsystem string) ObserveRequestFunc {
@@ -94,12 +99,13 @@ func ObserveRequest(namespace, subsystem string) ObserveRequestFunc {
 		)
 	}
 
-	return func(code int, host, method, proto string, begin time.Time) {
+	return func(code int, host, method, proto, route string, begin time.Time) {
 		requestLatencies[key].With(
 			labelStatusCode, strconv.Itoa(code),
 			labelHost, host,
 			labelMethod, method,
 			labelProto, proto,
+			labelRoute, route,
 		).Observe(time.Since(begin).Seconds())
 	}
 }


### PR DESCRIPTION
* add `route` to transport logs
* track `method` and `route` correctly in transport metrics