### PR TITLE
Constrain the API on locale type

### DIFF
--- a/sdk/ios/Configsum/Inputs/Context.swift
+++ b/sdk/ios/Configsum/Inputs/Context.swift
@@ -59,11 +59,7 @@ public class Context: Codable {
                 user: User?) {
         let secondsOffset = TimeZone.current.secondsFromGMT()
         
-        let languageCode = locale.languageCode!
-        let regionCode = locale.regionCode!
-        let formattedLocale = languageCode + "_" + regionCode
-        
-        let location = Location(locale: formattedLocale, timezoneOffset: secondsOffset)
+        let location = Location(locale: locale.identifier, timezoneOffset: secondsOffset)
         let os = OS(platform: platform,
                     version: osVersion)
         self.app = App(version: appVersion)

--- a/sdk/ios/Configsum/Inputs/Context.swift
+++ b/sdk/ios/Configsum/Inputs/Context.swift
@@ -7,9 +7,8 @@
 import Foundation
 
 public enum Platform: String, Codable {
-    case android
     case iOS
-    case watchOS
+    case watchOS = "WatchOS"
 }
 
 public struct User: Codable {
@@ -24,7 +23,7 @@ public class Context: Codable {
     private let metadata: Metadata?
     private let app: App
     private let device: Device
-    private let user: User
+    private let user: User?
     
     enum CodingKeys: String, CodingKey {
         case app
@@ -53,13 +52,18 @@ public class Context: Codable {
     }
     
     public init(appVersion: String,
-                locale: String,
+                locale: Locale,
                 platform: Platform,
                 osVersion: String,
                 metadata: Metadata?,
-                user: User) {
+                user: User?) {
         let secondsOffset = TimeZone.current.secondsFromGMT()
-        let location = Location(locale: locale, timezoneOffset: secondsOffset)
+        
+        let languageCode = locale.languageCode!
+        let regionCode = locale.regionCode!
+        let formattedLocale = languageCode + "_" + regionCode
+        
+        let location = Location(locale: formattedLocale, timezoneOffset: secondsOffset)
         let os = OS(platform: platform,
                     version: osVersion)
         self.app = App(version: appVersion)
@@ -73,15 +77,15 @@ public class Context: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.app = try container.decode(App.self, forKey: .app)
         self.device = try container.decode(Device.self, forKey: .device)
-        self.metadata = try container.decode(Metadata.self, forKey: .metadata)
-        self.user = try container.decode(User.self, forKey: .user)
+        self.metadata = try container.decodeIfPresent(Metadata.self, forKey: .metadata)
+        self.user = try container.decodeIfPresent(User.self, forKey: .user)
     }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(app, forKey: .app)
         try container.encode(device, forKey: .device)
-        try container.encode(metadata, forKey: .metadata)
-        try container.encode(user, forKey: .user)
+        try container.encodeIfPresent(metadata, forKey: .metadata)
+        try container.encodeIfPresent(user, forKey: .user)
     }
 }

--- a/sdk/ios/ConfigsumTests/ContextTests.swift
+++ b/sdk/ios/ConfigsumTests/ContextTests.swift
@@ -37,7 +37,7 @@ class ContextTests: XCTestCase {
                                                 from: dataFromJSONFile as Data)
         
         let context = Context(appVersion: "8.6.0",
-                              locale: "en-US",
+                              locale: Locale.current,
                               platform: .iOS,
                               osVersion: "11.0",
                               metadata: nil,
@@ -58,7 +58,7 @@ class ContextTests: XCTestCase {
                                                 from: dataFromJSONFile as Data)
         
         let context = Context(appVersion: "8.6.0",
-                              locale: "en-US",
+                              locale: Locale.current,
                               platform: .iOS,
                               osVersion: "11.0",
                               metadata: ["name": "testName",
@@ -80,7 +80,7 @@ class ContextTests: XCTestCase {
                                                 from: dataFromJSONFile as Data)
         
         let context = Context(appVersion: "8.6.0",
-                              locale: "en-US",
+                              locale: Locale.current,
                               platform: .iOS,
                               osVersion: "11.0",
                               metadata: ["name": "testName",

--- a/sdk/ios/ConfigsumTests/IntegrationTests.swift
+++ b/sdk/ios/ConfigsumTests/IntegrationTests.swift
@@ -22,8 +22,8 @@ class IntegrationTests: XCTestCase {
                                       urlScheme: "http")
         self.configsum = Configsum(environment: environment)
         self.attributes = Context(appVersion: "8.6.7",
-                                     locale: "en_GB",
-                                     platform: .android,
+                                     locale: Locale.current,
+                                     platform: .watchOS,
                                      osVersion: "8.0",
                                      metadata: nil,
                                      user: User(age: 20))

--- a/sdk/ios/ConfigsumTests/contextWithComplexMetadata.json
+++ b/sdk/ios/ConfigsumTests/contextWithComplexMetadata.json
@@ -17,7 +17,7 @@
             "version" : "11.0"
         },
         "location" : {
-            "locale" : "en-US",
+            "locale" : "en_US",
             "timezoneOffset" : 3600
         }
     },

--- a/sdk/ios/ConfigsumTests/contextWithMetadata.json
+++ b/sdk/ios/ConfigsumTests/contextWithMetadata.json
@@ -12,7 +12,7 @@
             "version" : "11.0"
         },
         "location" : {
-            "locale" : "en-US",
+            "locale" : "en_US",
             "timezoneOffset" : 3600
         }
     },

--- a/sdk/ios/ConfigsumTests/contextWithoutMetadata.json
+++ b/sdk/ios/ConfigsumTests/contextWithoutMetadata.json
@@ -9,7 +9,7 @@
             "version" : "11.0"
         },
         "location" : {
-            "locale" : "en-US",
+            "locale" : "en_US",
             "timezoneOffset" : 3600
         }
     },


### PR DESCRIPTION
To enforce type safety we changed to API to accept a Locale type instead of a string.

* omit encoding in the payload attributes that are nil
* made User as a optional parameter for Context