### PR TITLE
Allow `null` as value for context metadata

### DIFF
--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -50,7 +50,7 @@ const requestCapabilities = `
       "type": "object",
       "properties": {
         "location": {
-          "type": "object",
+          "type": [ "null", "object" ],
           "properties": {
             "locale": {
               "description": "The device's locale setting according to ISO 639-3 and/or BCP 47.",


### PR DESCRIPTION
Some clients might not omit the field if it's not present and send a `null` as value, to not reject the entire request we allow null value.