### PR TITLE
Implement first client endpoints

### DIFF
--- a/pkg/client/endpoint.go
+++ b/pkg/client/endpoint.go
@@ -1,0 +1,88 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+type createRequest struct {
+	name string
+}
+
+type createResponse struct {
+	CreatedAt time.Time `json:"created_at"`
+	Deleted   bool      `json:"deleted"`
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+}
+
+func (r createResponse) StatusCode() int {
+	return http.StatusCreated
+}
+
+type listResponse struct {
+	clientTokens clientTokens
+}
+
+func (r listResponse) MarshalJSON() ([]byte, error) {
+	type client struct {
+		CreatedAt time.Time `json:"created_at"`
+		Deleted   bool      `json:"deleted"`
+		ID        string    `json:"id"`
+		Name      string    `json:"name"`
+		Token     string    `json:"token"`
+	}
+
+	cs := []client{}
+
+	for c, t := range r.clientTokens {
+		cs = append(cs, client{
+			CreatedAt: c.createdAt,
+			Deleted:   c.deleted,
+			ID:        c.id,
+			Name:      c.name,
+			Token:     t.secret,
+		})
+	}
+
+	return json.Marshal(struct {
+		Clients []client `json:"clients"`
+	}{
+		Clients: cs,
+	})
+}
+
+func createEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		r := request.(createRequest)
+
+		c, err := svc.Create(r.name)
+		if err != nil {
+			return nil, err
+		}
+
+		return createResponse{
+			CreatedAt: c.createdAt,
+			Deleted:   c.deleted,
+			ID:        c.id,
+			Name:      c.name,
+		}, nil
+	}
+}
+
+func listEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		ct, err := svc.ListWithToken()
+		if err != nil {
+			return nil, err
+		}
+
+		return listResponse{
+			clientTokens: ct,
+		}, nil
+	}
+}

--- a/pkg/client/inmen.go
+++ b/pkg/client/inmen.go
@@ -17,6 +17,20 @@ func NewInmemRepo() Repo {
 	}
 }
 
+func (r *inmemRepo) List() (List, error) {
+	cs := List{}
+
+	for _, c := range r.clients {
+		if c.deleted {
+			continue
+		}
+
+		cs = append(cs, c)
+	}
+
+	return cs, nil
+}
+
 func (r *inmemRepo) Lookup(id string) (Client, error) {
 	c, ok := r.clients[id]
 	if !ok {
@@ -55,6 +69,16 @@ func NewInmemTokenRepo() TokenRepo {
 	return &inmemTokenRepo{
 		tokens: map[string]Token{},
 	}
+}
+
+func (r *inmemTokenRepo) GetLatest(clientID string) (Token, error) {
+	for _, t := range r.tokens {
+		if t.clientID == clientID {
+			return t, nil
+		}
+	}
+
+	return Token{}, errors.Wrapf(errors.ErrNotFound, "no token for %s'", clientID)
 }
 
 func (r *inmemTokenRepo) Lookup(secret string) (Token, error) {

--- a/pkg/client/inmen_test.go
+++ b/pkg/client/inmen_test.go
@@ -2,12 +2,20 @@ package client
 
 import "testing"
 
+func TestInmemRepoList(t *testing.T) {
+	testRepoList(t, prepareInmemRepo)
+}
+
 func TestInmemRepoLookup(t *testing.T) {
 	testRepoLookup(t, prepareInmemRepo)
 }
 
 func TestInmemRepoLookupNotFound(t *testing.T) {
 	testRepoLookupNotFound(t, prepareInmemRepo)
+}
+
+func TestInmemTokenRepoGetLatest(t *testing.T) {
+	testTokenRepoGetLatest(t, prepareInmemTokenRepo)
 }
 
 func TestInmemTokenRepoLookup(t *testing.T) {

--- a/pkg/client/instrument.go
+++ b/pkg/client/instrument.go
@@ -32,6 +32,14 @@ func NewRepoInstrumentMiddleware(
 	}
 }
 
+func (r *instrumentRepo) List() (cs List, err error) {
+	defer func(begin time.Time) {
+		r.opObserve(r.store, labelRepo, "List", begin, err)
+	}(time.Now())
+
+	return r.next.List()
+}
+
 func (r *instrumentRepo) Lookup(id string) (client Client, err error) {
 	defer func(begin time.Time) {
 		r.opObserve(r.store, labelRepo, "Lookup", begin, err)
@@ -85,6 +93,14 @@ func NewTokenRepoInstrumentMiddleware(
 	}
 }
 
+func (r *instrumentTokenRepo) GetLatest(clientID string) (token Token, err error) {
+	defer func(begin time.Time) {
+		r.opObserve(r.store, labelRepoToken, "GetLatest", begin, err)
+	}(time.Now())
+
+	return r.next.GetLatest(clientID)
+}
+
 func (r *instrumentTokenRepo) Lookup(secret string) (token Token, err error) {
 	defer func(begin time.Time) {
 		r.opObserve(r.store, labelRepoToken, "Lookup", begin, err)
@@ -115,8 +131,4 @@ func (r *instrumentTokenRepo) teardown() (err error) {
 	}(time.Now())
 
 	return r.next.teardown()
-}
-
-func (r *instrumentTokenRepo) track(begin time.Time, err error, op string) {
-	r.opObserve(r.store, labelRepoToken, op, begin, err)
 }

--- a/pkg/client/postgres_test.go
+++ b/pkg/client/postgres_test.go
@@ -15,12 +15,24 @@ import (
 
 var pgURI string
 
+func TestPGRepoList(t *testing.T) {
+	testRepoList(t, preparePGRepo)
+}
+
+func TestPGRepoListEmpty(t *testing.T) {
+	testRepoListEmpty(t, preparePGRepo)
+}
+
 func TestPGRepoLookup(t *testing.T) {
 	testRepoLookup(t, preparePGRepo)
 }
 
 func TestPGRepoLookupNotFound(t *testing.T) {
 	testRepoLookupNotFound(t, preparePGRepo)
+}
+
+func TestPGTokenRepoGetLatest(t *testing.T) {
+	testTokenRepoGetLatest(t, preparePGTokenRepo)
 }
 
 func TestPGTokenRepoLookup(t *testing.T) {

--- a/pkg/client/repo.go
+++ b/pkg/client/repo.go
@@ -11,10 +11,14 @@ type Client struct {
 	createdAt time.Time
 }
 
+// List is a collection of Clients.
+type List []Client
+
 // Repo for Client interactions.
 type Repo interface {
 	lifecycle
 
+	List() (List, error)
 	Lookup(id string) (Client, error)
 	Store(id, name string) (Client, error)
 }
@@ -26,6 +30,7 @@ type RepoMiddleware func(Repo) Repo
 type TokenRepo interface {
 	lifecycle
 
+	GetLatest(clientID string) (Token, error)
 	Lookup(secret string) (Token, error)
 	Store(clientID, secret string) (Token, error)
 }

--- a/pkg/client/repo_test.go
+++ b/pkg/client/repo_test.go
@@ -13,6 +13,50 @@ import (
 
 type prepareRepoFunc func(t *testing.T) Repo
 
+func testRepoList(t *testing.T, p prepareRepoFunc) {
+	var (
+		repo = p(t)
+		seed = rand.New(rand.NewSource(time.Now().UnixNano()))
+		want = rand.Intn(12)
+	)
+
+	for i := 0; i < want; i++ {
+		name := generate.RandomString(24)
+
+		id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = repo.Store(id.String(), name)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cs, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have := len(cs); have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testRepoListEmpty(t *testing.T, p prepareRepoFunc) {
+	repo := p(t)
+
+	cs, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := len(cs), 0; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
 func testRepoLookup(t *testing.T, p prepareRepoFunc) {
 	var (
 		name = generate.RandomString(24)
@@ -61,6 +105,45 @@ func testRepoLookupNotFound(t *testing.T, p prepareRepoFunc) {
 }
 
 type prepareTokenRepoFunc func(t *testing.T) TokenRepo
+
+func testTokenRepoGetLatest(t *testing.T, p prepareTokenRepoFunc) {
+	var (
+		repo = p(t)
+		seed = rand.New(rand.NewSource(time.Now().UnixNano()))
+	)
+
+	secret, err := generate.SecureToken(secretByteLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientID, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Store(clientID.String(), secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := repo.GetLatest(clientID.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := token.clientID, clientID.String(); have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := token.deleted, false; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := token.secret, secret; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
 
 func testTokenRepoLookup(t *testing.T, p prepareTokenRepoFunc) {
 	var (

--- a/pkg/client/service.go
+++ b/pkg/client/service.go
@@ -1,16 +1,25 @@
 package client
 
 import (
-	"github.com/pkg/errors"
+	"math/rand"
+	"time"
+
+	"github.com/oklog/ulid"
+
+	"github.com/lifesum/configsum/pkg/errors"
+	"github.com/lifesum/configsum/pkg/generate"
 )
 
 // Service provides Clients.
 type Service interface {
+	Create(name string) (Client, error)
+	ListWithToken() (clientTokens, error)
 	LookupBySecret(secret string) (Client, error)
 }
 
 type service struct {
 	repo      Repo
+	seed      *rand.Rand
 	tokenRepo TokenRepo
 }
 
@@ -18,8 +27,53 @@ type service struct {
 func NewService(repo Repo, tokenRepo TokenRepo) Service {
 	return &service{
 		repo:      repo,
+		seed:      rand.New(rand.NewSource(time.Now().UnixNano())),
 		tokenRepo: tokenRepo,
 	}
+}
+
+func (s *service) Create(name string) (Client, error) {
+	clientID, err := ulid.New(ulid.Timestamp(time.Now()), s.seed)
+	if err != nil {
+		return Client{}, err
+	}
+
+	c, err := s.repo.Store(clientID.String(), name)
+	if err != nil {
+		return Client{}, err
+	}
+
+	secret, err := generate.SecureToken(secretByteLen)
+	if err != nil {
+		return Client{}, err
+	}
+
+	_, err = s.tokenRepo.Store(clientID.String(), secret)
+	if err != nil {
+		return Client{}, err
+	}
+
+	return c, nil
+}
+
+func (s *service) ListWithToken() (clientTokens, error) {
+	cs, err := s.repo.List()
+	if err != nil {
+		return nil, err
+	}
+
+	ct := clientTokens{}
+
+	for _, c := range cs {
+		t, err := s.tokenRepo.GetLatest(c.id)
+		if err != nil {
+			continue
+		}
+
+		ct[c] = t
+	}
+
+	return ct, nil
 }
 
 func (s *service) LookupBySecret(secret string) (Client, error) {
@@ -30,3 +84,7 @@ func (s *service) LookupBySecret(secret string) (Client, error) {
 
 	return s.repo.Lookup(t.clientID)
 }
+
+// clientTokens is a mapping of Client to single Token, usually the latest one
+// for the specific Client.
+type clientTokens map[Client]Token

--- a/pkg/client/service_test.go
+++ b/pkg/client/service_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"math/rand"
+	"reflect"
 	"testing"
 	"time"
 
@@ -9,6 +10,60 @@ import (
 
 	"github.com/lifesum/configsum/pkg/generate"
 )
+
+func TestServiceCreate(t *testing.T) {
+	var (
+		name      = generate.RandomString(12)
+		repo      = prepareInmemRepo(t)
+		tokenRepo = prepareInmemTokenRepo(t)
+		svc       = NewService(repo, tokenRepo)
+	)
+
+	clientSVC, err := svc.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientRepo, err := repo.Lookup(clientSVC.id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := clientSVC, clientRepo; !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	token, err := tokenRepo.GetLatest(clientSVC.id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := token.clientID, clientSVC.id; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func TestListWithToken(t *testing.T) {
+	var (
+		numClients = rand.New(rand.NewSource(time.Now().UnixNano())).Intn(24)
+		repo       = prepareInmemRepo(t)
+		tokenRepo  = prepareInmemTokenRepo(t)
+		svc        = NewService(repo, tokenRepo)
+	)
+
+	for i := 0; i < numClients; i++ {
+		testCreateClientWithToken(repo, tokenRepo, t)
+	}
+
+	ct, err := svc.ListWithToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := len(ct), numClients; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
 
 func TestServiceLookupBySecret(t *testing.T) {
 	var (
@@ -45,5 +100,29 @@ func TestServiceLookupBySecret(t *testing.T) {
 
 	if have, want := c.id, clientID; err != nil {
 		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testCreateClientWithToken(repo Repo, tokenRepo TokenRepo, t *testing.T) {
+	seed := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	clientID, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secret, err := generate.SecureToken(secretByteLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := repo.Store(clientID.String(), generate.RandomString(12))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = tokenRepo.Store(c.id, secret)
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -2,10 +2,42 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+
+	"github.com/lifesum/configsum/pkg/errors"
 )
 
 const headerToken = "X-Configsum-Token"
+
+// MakeHandler returns an http.Handler for Service.
+func MakeHandler(svc Service, opts ...kithttp.ServerOption) http.Handler {
+	r := mux.NewRouter()
+	r.StrictSlash(false)
+
+	r.Methods("GET").Path(`/`).Name("clientList").Handler(
+		kithttp.NewServer(
+			listEndpoint(svc),
+			decodeListRequest,
+			kithttp.EncodeJSONResponse,
+			opts...,
+		),
+	)
+
+	r.Methods("POST").Path("/").Name("clientCreate").Handler(
+		kithttp.NewServer(
+			createEndpoint(svc),
+			decodeCreateRequest,
+			kithttp.EncodeJSONResponse,
+			opts...,
+		),
+	)
+
+	return r
+}
 
 // HTTPToContext moves the Client secret token from request header to context.
 func HTTPToContext(
@@ -18,4 +50,25 @@ func HTTPToContext(
 	}
 
 	return context.WithValue(ctx, contextKeySecret, secret)
+}
+func decodeCreateRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	v := struct {
+		Name string `json:"name"`
+	}{}
+
+	if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
+		return nil, errors.Wrap(errors.ErrInvalidPayload, err.Error())
+	}
+
+	if v.Name == "" {
+		return nil, errors.Wrap(errors.ErrInvalidPayload, "missing name")
+	}
+
+	return createRequest{
+		name: v.Name,
+	}, nil
+}
+
+func decodeListRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	return nil, nil
 }

--- a/pkg/client/transport_test.go
+++ b/pkg/client/transport_test.go
@@ -1,12 +1,60 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"testing"
 
+	"github.com/lifesum/configsum/pkg/errors"
 	"github.com/lifesum/configsum/pkg/generate"
 )
+
+func TestDecodeCreateRequest(t *testing.T) {
+	var (
+		ctx     = context.TODO()
+		name    = generate.RandomString(12)
+		payload = bytes.NewBufferString(fmt.Sprintf(`{"name": "%s"}`, name))
+		r       = httptest.NewRequest("POST", "/", payload)
+	)
+
+	raw, err := decodeCreateRequest(ctx, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := createRequest{
+		name: name,
+	}
+
+	if have := raw.(createRequest); !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func TestDecodeCreateRequestInvalid(t *testing.T) {
+	cases := []string{
+		``,   // Empty body.
+		`{}`, // name missing
+	}
+
+	for _, c := range cases {
+		var (
+			ctx     = context.TODO()
+			payload = bytes.NewBufferString(c)
+			r       = httptest.NewRequest("POST", "/", payload)
+		)
+
+		_, err := decodeCreateRequest(ctx, r)
+		if have, want := errors.Cause(err), errors.ErrInvalidPayload; have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+	}
+
+}
 
 func TestHTTPToContext(t *testing.T) {
 	secret, err := generate.SecureToken(secretByteLen)
@@ -35,5 +83,4 @@ func TestHTTPToContext(t *testing.T) {
 			t.Errorf("have %v, want %v", have, want)
 		}
 	}
-
 }

--- a/pkg/config/transport_test.go
+++ b/pkg/config/transport_test.go
@@ -126,7 +126,7 @@ func TestDecodeUserRequest(t *testing.T) {
 	}
 
 	if have := raw.(userRequest); !reflect.DeepEqual(have, want) {
-		t.Errorf("\nhave %#v\nwant %#v", have, want)
+		t.Errorf("have %v, want %v", have, want)
 	}
 }
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -30,6 +30,11 @@ func Cause(err error) error {
 	return errors.Cause(err)
 }
 
+// New is a wraper over github.com/pkg/errors.New.
+func New(message string) error {
+	return errors.New(message)
+}
+
 // Wrap is a wrapper over github.com/pkg/errors.Wrap.
 func Wrap(err error, message string) error {
 	return errors.Wrap(err, message)

--- a/pkg/transport/http/transport.go
+++ b/pkg/transport/http/transport.go
@@ -1,0 +1,110 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+
+	"github.com/lifesum/configsum/pkg/errors"
+	"github.com/lifesum/configsum/pkg/instrument"
+)
+
+type contextKey string
+
+const (
+	ctxKeyTimeBegin contextKey = "begin"
+	ctxKeyRoute     contextKey = "route"
+)
+
+// Headers.
+const (
+	headerContentType = "Content-Type"
+)
+
+// ErrorEncoder translates domain specific errors to HTTP status codes.
+func ErrorEncoder(_ context.Context, err error, w http.ResponseWriter) {
+	switch errors.Cause(err) {
+	case errors.ErrExists:
+		w.WriteHeader(http.StatusConflict)
+	case errors.ErrNotFound:
+		w.WriteHeader(http.StatusNotFound)
+	case errors.ErrClientNotFound, errors.ErrSecretMissing:
+		w.WriteHeader(http.StatusUnauthorized)
+	case errors.ErrSignatureMissing, errors.ErrSignatureMissmatch, errors.ErrUserIDMissing:
+		w.WriteHeader(http.StatusUnauthorized)
+	case errors.ErrInvalidPayload:
+		w.WriteHeader(http.StatusBadRequest)
+	default:
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	w.Header().Set(headerContentType, "application/json; charset=utf-8")
+
+	_ = json.NewEncoder(w).Encode(struct {
+		Reason string `json:"reason"`
+	}{
+		Reason: err.Error(),
+	})
+}
+
+// PopulateRequestContext extracts common information about a request and stores
+// it in the context.
+func PopulateRequestContext(ctx context.Context, r *http.Request) context.Context {
+	route := "unknown"
+
+	if current := mux.CurrentRoute(r); current != nil {
+		route = current.GetName()
+	}
+
+	ctx = context.WithValue(ctx, ctxKeyTimeBegin, time.Now())
+	ctx = context.WithValue(ctx, ctxKeyRoute, route)
+
+	return ctx
+}
+
+// ServerFinalizer instruments handler calls to expose Prometheus metrics and
+/// log request/response information.
+func ServerFinalizer(
+	logger log.Logger,
+	reqObserve instrument.ObserveRequestFunc,
+) kithttp.ServerFinalizerFunc {
+	return func(ctx context.Context, code int, r *http.Request) {
+		var (
+			begin  = ctx.Value(ctxKeyTimeBegin).(time.Time)
+			method = ctx.Value(kithttp.ContextKeyRequestMethod).(string)
+			host   = ctx.Value(kithttp.ContextKeyRequestHost).(string)
+			proto  = ctx.Value(kithttp.ContextKeyRequestProto).(string)
+			route  = ctx.Value(ctxKeyRoute).(string)
+		)
+
+		_ = logger.Log(
+			"duration", time.Since(begin).Nanoseconds(),
+			"request", map[string]interface{}{
+				"authorization":    ctx.Value(kithttp.ContextKeyRequestAuthorization),
+				"header":           r.Header,
+				"host":             host,
+				"method":           method,
+				"path":             ctx.Value(kithttp.ContextKeyRequestPath),
+				"proto":            proto,
+				"referer":          ctx.Value(kithttp.ContextKeyRequestReferer),
+				"remoteAddr":       ctx.Value(kithttp.ContextKeyRequestRemoteAddr),
+				"requestId":        ctx.Value(kithttp.ContextKeyRequestXRequestID),
+				"requestUri":       ctx.Value(kithttp.ContextKeyRequestURI),
+				"transferEncoding": r.TransferEncoding,
+			},
+			"response", map[string]interface{}{
+				"header":     ctx.Value(kithttp.ContextKeyResponseHeaders).(http.Header),
+				"size":       ctx.Value(kithttp.ContextKeyResponseSize).(int64),
+				"statusCode": code,
+			},
+			"route", route,
+		)
+
+		reqObserve(code, host, method, proto, route, begin)
+	}
+}

--- a/pkg/ui/transport.go
+++ b/pkg/ui/transport.go
@@ -26,13 +26,8 @@ const tmplIndex = `<!DOCTYPE html>
 </html>`
 
 // MakeHandler returns am http.Handler for the UI.
-func MakeHandler(logger log.Logger, base string, local bool) (http.Handler, error) {
+func MakeHandler(logger log.Logger, base string, local bool) http.Handler {
 	r := mux.NewRouter()
-
-	tplRoot, err := template.New("root").Parse(tmplIndex)
-	if err != nil {
-		return nil, err
-	}
 
 	r.Methods("GET").PathPrefix("/scripts").Name("scripts").Handler(
 		http.FileServer(_escFS(local)),
@@ -41,6 +36,8 @@ func MakeHandler(logger log.Logger, base string, local bool) (http.Handler, erro
 	r.Methods("GET").PathPrefix("/styles").Name("styles").Handler(
 		http.FileServer(_escFS(local)),
 	)
+
+	tplRoot := template.Must(template.New("root").Parse(tmplIndex))
 
 	r.Methods("GET").PathPrefix("/").Name("root").HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -52,5 +49,5 @@ func MakeHandler(logger log.Logger, base string, local bool) (http.Handler, erro
 		},
 	)
 
-	return r, nil
+	return r
 }


### PR DESCRIPTION
In preparation for client CRUD in the Console we flesh out the handler with listing and create endpoints. Along the way a lot of structural changes had to be made to benefit from the auxiliary code we set up for
the config package.

* implement client create
* implement client listing
* extend client repos
* extract common ServerOption into transport/http