### PR TITLE
Fix nomenclature for config rendering

### DIFF
--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -41,16 +41,16 @@ func (l *location) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
-type userContext struct {
+type renderContext struct {
 	Device device `json:"device"`
 }
 
-type userRequest struct {
+type renderRequest struct {
 	baseConfig string
-	context    userContext
+	context    renderContext
 }
 
-type userResponse struct {
+type renderResponse struct {
 	baseID    string
 	baseName  string
 	clientID  string
@@ -59,14 +59,14 @@ type userResponse struct {
 	createdAt time.Time
 }
 
-func (r userResponse) StatusCode() int {
+func (r renderResponse) StatusCode() int {
 	return http.StatusCreated
 }
 
-func userEndpoint(svc ServiceUser) endpoint.Endpoint {
+func renderEndpoint(svc ServiceUser) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		var (
-			req      = request.(userRequest)
+			req      = request.(renderRequest)
 			clientID = ctx.Value(client.ContextKeyClientID).(string)
 			userID   = ctx.Value(auth.ContextKeyUserID).(string)
 		)
@@ -76,7 +76,7 @@ func userEndpoint(svc ServiceUser) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return userResponse{
+		return renderResponse{
 			baseID:    c.baseID,
 			baseName:  req.baseConfig,
 			clientID:  clientID,

--- a/pkg/config/transport.go
+++ b/pkg/config/transport.go
@@ -44,9 +44,9 @@ func MakeHandler(
 
 	r.Methods("PUT").Path(`/{baseConfig:[a-z0-9\-]+}`).Name("configUser").Handler(
 		kithttp.NewServer(
-			auth(userEndpoint(svc)),
-			decodeJSONSchema(decodeUserRequest, decodeClientPayloadSchema),
-			encodeUserResponse,
+			auth(renderEndpoint(svc)),
+			decodeJSONSchema(decodeRenderRequest, decodeClientPayloadSchema),
+			encodeRenderResponse,
 			append(
 				opts,
 				kithttp.ServerBefore(extractMuxVars(varBaseConfig)),
@@ -103,31 +103,31 @@ func extractMuxVars(keys ...muxVar) kithttp.RequestFunc {
 	}
 }
 
-func decodeUserRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+func decodeRenderRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 	baseConfig, ok := ctx.Value(varBaseConfig).(string)
 	if !ok {
 		return nil, errors.Wrap(errors.ErrVarMissing, "baseConfig missing")
 	}
 
-	c := userContext{}
+	c := renderContext{}
 
 	err := json.NewDecoder(r.Body).Decode(&c)
 	if err != nil {
 		return nil, err
 	}
 
-	return userRequest{
+	return renderRequest{
 		baseConfig: baseConfig,
 		context:    c,
 	}, nil
 }
 
-func encodeUserResponse(
+func encodeRenderResponse(
 	_ context.Context,
 	w http.ResponseWriter,
 	response interface{},
 ) error {
-	r := response.(userResponse)
+	r := response.(renderResponse)
 
 	w.Header().Set(headerContentType, "application/json; charset=utf-8")
 	w.Header().Set(headerBaseID, r.baseID)

--- a/pkg/config/transport_test.go
+++ b/pkg/config/transport_test.go
@@ -99,7 +99,7 @@ func TestDecodeJSONSchemaMissingField(t *testing.T) {
 	}
 }
 
-func TestDecodeUserRequest(t *testing.T) {
+func TestDecodeRenderRequest(t *testing.T) {
 	var (
 		baseConfig = generate.RandomString(6)
 		ctx        = context.WithValue(context.Background(), varBaseConfig, baseConfig)
@@ -109,14 +109,14 @@ func TestDecodeUserRequest(t *testing.T) {
 		r          = httptest.NewRequest("PUT", target, payload)
 	)
 
-	raw, err := decodeUserRequest(ctx, r)
+	raw, err := decodeRenderRequest(ctx, r)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	want := userRequest{
+	want := renderRequest{
 		baseConfig: baseConfig,
-		context: userContext{
+		context: renderContext{
 			Device: device{
 				Location: location{
 					locale: locale,
@@ -125,7 +125,7 @@ func TestDecodeUserRequest(t *testing.T) {
 		},
 	}
 
-	if have := raw.(userRequest); !reflect.DeepEqual(have, want) {
+	if have := raw.(renderRequest); !reflect.DeepEqual(have, want) {
 		t.Errorf("have %v, want %v", have, want)
 	}
 }


### PR DESCRIPTION
Cleans house for some leftovers that weren't adjusted as the endpoint evolved from the notion of user to render.