### PR TITLE
Implement base configs completely

### DIFF
--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/go-kit/kit/endpoint"
@@ -13,6 +14,161 @@ import (
 	"github.com/lifesum/configsum/pkg/client"
 	"github.com/lifesum/configsum/pkg/errors"
 )
+
+type baseCreateRequest struct {
+	clientID string
+	name     string
+}
+
+func baseCreateEndpoint(svc BaseService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(baseCreateRequest)
+
+		c, err := svc.Create(req.clientID, req.name)
+		if err != nil {
+			return nil, err
+		}
+
+		return responseBaseConfig{config: c}, nil
+	}
+}
+
+type baseGetRequest struct {
+	id string
+}
+
+func baseGetEndpoint(svc BaseService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(baseGetRequest)
+
+		c, err := svc.Get(req.id)
+		if err != nil {
+			return nil, err
+		}
+
+		return responseBaseConfig{config: c}, nil
+	}
+}
+
+type baseListRequest struct{}
+
+type baseListResponse struct {
+	baseConfigs []BaseConfig
+}
+
+func (r baseListResponse) MarshalJSON() ([]byte, error) {
+	cs := []responseBaseConfig{}
+
+	for _, c := range r.baseConfigs {
+		cs = append(cs, responseBaseConfig{config: c})
+	}
+
+	return json.Marshal(struct {
+		BaseConfigs []responseBaseConfig `json:"base_configs"`
+	}{
+		BaseConfigs: cs,
+	})
+}
+
+type responseParameter struct {
+	Name  string      `json:"name"`
+	Type  string      `json:"type"`
+	Value interface{} `json:"value"`
+}
+
+type responseParameters []responseParameter
+
+func (r responseParameters) Len() int {
+	return len(r)
+}
+
+func (r responseParameters) Less(i, j int) bool {
+	return r[i].Name > r[j].Name
+}
+
+func (r responseParameters) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+type responseBaseConfig struct {
+	config BaseConfig
+}
+
+func (r responseBaseConfig) MarshalJSON() ([]byte, error) {
+	v := struct {
+		ClientID   string             `json:"client_id"`
+		Deleted    bool               `json:"deleted"`
+		ID         string             `json:"id"`
+		Name       string             `json:"name"`
+		Parameters responseParameters `json:"parameters"`
+		CreatedAt  time.Time          `json:"created_at"`
+		UpdatedAt  time.Time          `json:"updated_at"`
+	}{
+		ClientID:  r.config.ClientID,
+		Deleted:   r.config.Deleted,
+		ID:        r.config.ID,
+		Name:      r.config.Name,
+		CreatedAt: r.config.CreatedAt,
+		UpdatedAt: r.config.UpdatedAt,
+	}
+
+	ps := responseParameters{}
+
+	for k, val := range r.config.Parameters {
+		p := responseParameter{
+			Name:  k,
+			Value: val,
+		}
+
+		switch val.(type) {
+		case bool:
+			p.Type = "bool"
+		case float64:
+			p.Type = "number"
+		case string:
+			p.Type = "string"
+		default:
+			p.Type = "unknown"
+		}
+
+		ps = append(ps, p)
+	}
+
+	sort.Sort(ps)
+
+	v.Parameters = ps
+
+	return json.Marshal(v)
+}
+
+func baseListEndpoint(svc BaseService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		cs, err := svc.List()
+		if err != nil {
+			return nil, err
+		}
+
+		return baseListResponse{baseConfigs: cs}, nil
+	}
+}
+
+type baseUpdateRequest struct {
+	id         string
+	parameters rendered
+}
+
+func baseUpdateEndpoint(svc BaseService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(baseUpdateRequest)
+
+		c, err := svc.Update(req.id, req.parameters)
+		if err != nil {
+			return nil, err
+		}
+
+		return responseBaseConfig{config: c}, nil
+	}
+}
 
 type device struct {
 	Location location `json:"location"`
@@ -41,16 +197,16 @@ func (l *location) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
-type renderContext struct {
+type userRenderContext struct {
 	Device device `json:"device"`
 }
 
-type renderRequest struct {
+type userRenderRequest struct {
 	baseConfig string
-	context    renderContext
+	context    userRenderContext
 }
 
-type renderResponse struct {
+type userRenderResponse struct {
 	baseID    string
 	baseName  string
 	clientID  string
@@ -59,14 +215,14 @@ type renderResponse struct {
 	createdAt time.Time
 }
 
-func (r renderResponse) StatusCode() int {
+func (r userRenderResponse) StatusCode() int {
 	return http.StatusCreated
 }
 
-func renderEndpoint(svc ServiceUser) endpoint.Endpoint {
+func userRenderEndpoint(svc UserService) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		var (
-			req      = request.(renderRequest)
+			req      = request.(userRenderRequest)
 			clientID = ctx.Value(client.ContextKeyClientID).(string)
 			userID   = ctx.Value(auth.ContextKeyUserID).(string)
 		)
@@ -76,7 +232,7 @@ func renderEndpoint(svc ServiceUser) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return renderResponse{
+		return userRenderResponse{
 			baseID:    c.baseID,
 			baseName:  req.baseConfig,
 			clientID:  clientID,

--- a/pkg/config/helper_test.go
+++ b/pkg/config/helper_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"math/rand"
-	"testing"
 	"time"
 )
 
@@ -11,12 +10,11 @@ const (
 	numCharacterSet = "0123456789"
 )
 
-var seed = rand.New(rand.NewSource(time.Now().UnixNano()))
-
-type prepareFunc func(t *testing.T) UserRepo
-
 func randString(charset string) string {
-	b := make([]byte, len(charset))
+	var (
+		b    = make([]byte, len(charset))
+		seed = rand.New(rand.NewSource(time.Now().UnixNano()))
+	)
 
 	for i := range b {
 		b[i] = charset[seed.Intn(len(charset))]

--- a/pkg/config/inmem.go
+++ b/pkg/config/inmem.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/lifesum/configsum/pkg/errors"
@@ -15,28 +16,115 @@ type inmemBaseRepo struct {
 }
 
 // NewInmemBaseRepo returns an in-memory backed BaseRepo implementation.
-func NewInmemBaseRepo(initial InmemBaseState) (BaseRepo, error) {
+func NewInmemBaseRepo(initial InmemBaseState) BaseRepo {
 	if initial == nil {
 		initial = InmemBaseState{}
 	}
 
 	return &inmemBaseRepo{
 		configs: initial,
-	}, nil
+	}
 }
 
-func (s *inmemBaseRepo) Get(clientID, name string) (BaseConfig, error) {
+func (s *inmemBaseRepo) Create(
+	id, clientID, name string,
+	parameters rendered,
+) (BaseConfig, error) {
+	_, ok := s.configs[clientID]
+	if !ok {
+		s.configs[clientID] = map[string]BaseConfig{}
+	}
+
+	_, ok = s.configs[clientID][name]
+	if ok {
+		return BaseConfig{}, errors.Wrapf(errors.ErrExists, "duplicate name '%s'", name)
+	}
+
+	c := BaseConfig{
+		ClientID:   clientID,
+		ID:         id,
+		Name:       name,
+		Parameters: parameters,
+		CreatedAt:  time.Now(),
+	}
+
+	s.configs[clientID][name] = c
+
+	return c, nil
+}
+
+func (s *inmemBaseRepo) GetByID(id string) (BaseConfig, error) {
+	for _, cs := range s.configs {
+		for _, c := range cs {
+			if c.ID == id {
+				return c, nil
+			}
+		}
+	}
+
+	return BaseConfig{}, errors.Wrapf(errors.ErrNotFound, "base config '%s'", id)
+}
+
+func (s *inmemBaseRepo) GetByName(clientID, name string) (BaseConfig, error) {
 	client, ok := s.configs[clientID]
 	if !ok {
-		return BaseConfig{}, errors.Wrap(errors.ErrNotFound, fmt.Sprintf("client id '%s'", clientID))
+		return BaseConfig{}, errors.Wrapf(errors.ErrNotFound, "client id '%s'", clientID)
 	}
 
 	bc, ok := client[name]
 	if !ok {
-		return BaseConfig{}, errors.Wrap(errors.ErrNotFound, fmt.Sprintf("base config name '%s'", name))
+		return BaseConfig{}, errors.Wrapf(errors.ErrNotFound, "base config name '%s'", name)
 	}
 
 	return bc, nil
+}
+
+func (s *inmemBaseRepo) List() (BaseList, error) {
+	cs := BaseList{}
+
+	for _, clientConfigs := range s.configs {
+		for _, c := range clientConfigs {
+			cs = append(cs, c)
+		}
+	}
+
+	sort.Sort(cs)
+
+	return cs, nil
+}
+
+func (s *inmemBaseRepo) Update(c BaseConfig) (BaseConfig, error) {
+	client, ok := s.configs[c.ClientID]
+	if !ok {
+		return BaseConfig{}, errors.Wrapf(errors.ErrNotFound, "id '%s'", c.ID)
+	}
+
+	_, ok = client[c.Name]
+	if !ok {
+		return BaseConfig{}, errors.Wrapf(errors.ErrNotFound, "id '%s'", c.ID)
+	}
+
+	c = BaseConfig{
+		ClientID:   c.ClientID,
+		Deleted:    c.Deleted,
+		ID:         c.ID,
+		Name:       c.Name,
+		Parameters: c.Parameters,
+		CreatedAt:  c.CreatedAt,
+		UpdatedAt:  time.Now(),
+	}
+
+	s.configs[c.ClientID][c.Name] = c
+
+	return c, nil
+}
+
+func (s *inmemBaseRepo) setup() error {
+	return nil
+}
+
+func (s *inmemBaseRepo) teardown() error {
+	return nil
 }
 
 type inmemUserState map[string]map[string][]UserConfig
@@ -47,11 +135,11 @@ type inmemUserRepo struct {
 }
 
 // NewInmemUserRepo returns an in-memory backed UserRepo implementation.
-func NewInmemUserRepo() (UserRepo, error) {
+func NewInmemUserRepo() UserRepo {
 	return &inmemUserRepo{
 		configs: inmemUserState{},
 		ids:     map[string]struct{}{},
-	}, nil
+	}
 }
 
 func (r *inmemUserRepo) Append(
@@ -106,10 +194,10 @@ func (r *inmemUserRepo) GetLatest(baseID, id string) (UserConfig, error) {
 	return cs[len(cs)-1], nil
 }
 
-func (r *inmemUserRepo) Setup() error {
+func (r *inmemUserRepo) setup() error {
 	return nil
 }
 
-func (r *inmemUserRepo) Teardown() error {
+func (r *inmemUserRepo) teardown() error {
 	return nil
 }

--- a/pkg/config/inmem_test.go
+++ b/pkg/config/inmem_test.go
@@ -2,6 +2,34 @@ package config
 
 import "testing"
 
+func TestInmemBaseRepoCreateDuplicate(t *testing.T) {
+	testBaseRepoCreateDuplicate(t, prepareInmemBaseRepo)
+}
+
+func TestInmemBaseRepoGetByID(t *testing.T) {
+	testBaseRepoGetByID(t, prepareInmemBaseRepo)
+}
+
+func TestInmemBaseRepoGetByIDNotFound(t *testing.T) {
+	testBaseRepoGetByIDNotFound(t, prepareInmemBaseRepo)
+}
+
+func TestInmemBaseRepoGetByName(t *testing.T) {
+	testBaseRepoGetByName(t, prepareInmemBaseRepo)
+}
+
+func TestInmemBaseRepoGetByNameNotFound(t *testing.T) {
+	testBaseRepoGetByNameNotFound(t, prepareInmemBaseRepo)
+}
+
+func TestInmemBaseRepoList(t *testing.T) {
+	testBaseRepoList(t, prepareInmemBaseRepo)
+}
+
+func TestInmemBaseRepoUpdate(t *testing.T) {
+	testBaseRepoUpdate(t, prepareInmemBaseRepo)
+}
+
 func TestInmenUserRepoGetLatest(t *testing.T) {
 	testUserRepoGetLatest(t, prepareInmenUserRepo)
 }
@@ -14,11 +42,10 @@ func TestInmemUserRepoAppendDuplicate(t *testing.T) {
 	testUserRepoAppendDuplicate(t, prepareInmenUserRepo)
 }
 
-func prepareInmenUserRepo(t *testing.T) UserRepo {
-	r, err := NewInmemUserRepo()
-	if err != nil {
-		t.Fatal(err)
-	}
+func prepareInmemBaseRepo(t *testing.T) BaseRepo {
+	return NewInmemBaseRepo(nil)
+}
 
-	return r
+func prepareInmenUserRepo(t *testing.T) UserRepo {
+	return NewInmemUserRepo()
 }

--- a/pkg/config/instrument.go
+++ b/pkg/config/instrument.go
@@ -6,15 +6,98 @@ import (
 	"github.com/lifesum/configsum/pkg/instrument"
 )
 
-const labelRepoUser = "user"
+const (
+	labelBaseRepo = "base"
+	labelUserRepo = "user"
+)
 
-type instrumentUserRepo struct {
+type instrumentBaseRepo struct {
+	next      BaseRepo
 	opObserve instrument.ObserveRepoFunc
-	next      UserRepo
 	store     string
 }
 
-// NewUserRepoInstrumentMiddleware wraps the next UserRepo Prometheus
+// NewBaseRepoInstrumentMiddleware wraps the next BaseRepo and add Prometheus
+// instrumentation capabilities.
+func NewBaseRepoInstrumentMiddleware(
+	opObserve instrument.ObserveRepoFunc,
+	store string,
+) BaseRepoMiddleware {
+	return func(next BaseRepo) BaseRepo {
+		return &instrumentBaseRepo{
+			next:      next,
+			opObserve: opObserve,
+			store:     store,
+		}
+	}
+}
+
+func (r *instrumentBaseRepo) Create(
+	id, clientID, name string,
+	parameters rendered,
+) (c BaseConfig, err error) {
+	defer func(begin time.Time) {
+		r.opObserve(r.store, labelBaseRepo, "Create", begin, err)
+	}(time.Now())
+
+	return r.next.Create(id, clientID, name, parameters)
+}
+
+func (r *instrumentBaseRepo) GetByID(id string) (c BaseConfig, err error) {
+	defer func(begin time.Time) {
+		r.opObserve(r.store, labelBaseRepo, "GetByID", begin, err)
+	}(time.Now())
+
+	return r.next.GetByID(id)
+}
+
+func (r *instrumentBaseRepo) GetByName(clientID, name string) (c BaseConfig, err error) {
+	defer func(begin time.Time) {
+		r.opObserve(r.store, labelBaseRepo, "GetByName", begin, err)
+	}(time.Now())
+
+	return r.next.GetByName(clientID, name)
+}
+
+func (r *instrumentBaseRepo) List() (l BaseList, err error) {
+	defer func(begin time.Time) {
+		r.opObserve(r.store, labelBaseRepo, "List", begin, err)
+	}(time.Now())
+
+	return r.next.List()
+}
+
+func (r *instrumentBaseRepo) Update(input BaseConfig) (bc BaseConfig, err error) {
+	defer func(begin time.Time) {
+		r.opObserve(r.store, labelBaseRepo, "Update", begin, err)
+	}(time.Now())
+
+	return r.next.Update(input)
+}
+
+func (r *instrumentBaseRepo) setup() (err error) {
+	defer func(begin time.Time) {
+		r.opObserve(r.store, labelBaseRepo, "setup", begin, err)
+	}(time.Now())
+
+	return r.next.setup()
+}
+
+func (r *instrumentBaseRepo) teardown() (err error) {
+	defer func(begin time.Time) {
+		r.opObserve(r.store, labelBaseRepo, "teardown", begin, err)
+	}(time.Now())
+
+	return r.next.teardown()
+}
+
+type instrumentUserRepo struct {
+	next      UserRepo
+	opObserve instrument.ObserveRepoFunc
+	store     string
+}
+
+// NewUserRepoInstrumentMiddleware wraps the next BaseRepo and add Prometheus
 // instrumentation capabilities.
 func NewUserRepoInstrumentMiddleware(
 	opObserve instrument.ObserveRepoFunc,
@@ -35,7 +118,7 @@ func (r *instrumentUserRepo) Append(
 	render rendered,
 ) (c UserConfig, err error) {
 	defer func(begin time.Time) {
-		r.opObserve(r.store, labelRepoUser, "Append", begin, err)
+		r.opObserve(r.store, labelUserRepo, "Append", begin, err)
 	}(time.Now())
 
 	return r.next.Append(id, baseID, userID, decisions, render)
@@ -45,24 +128,24 @@ func (r *instrumentUserRepo) GetLatest(
 	baseID, userID string,
 ) (c UserConfig, err error) {
 	defer func(begin time.Time) {
-		r.opObserve(r.store, labelRepoUser, "GetLatest", begin, err)
+		r.opObserve(r.store, labelUserRepo, "GetLatest", begin, err)
 	}(time.Now())
 
 	return r.next.GetLatest(baseID, userID)
 }
 
-func (r *instrumentUserRepo) Setup() (err error) {
+func (r *instrumentUserRepo) setup() (err error) {
 	defer func(begin time.Time) {
-		r.opObserve(r.store, labelRepoUser, "Setup", begin, err)
+		r.opObserve(r.store, labelUserRepo, "Setup", begin, err)
 	}(time.Now())
 
-	return r.next.Setup()
+	return r.next.setup()
 }
 
-func (r *instrumentUserRepo) Teardown() (err error) {
+func (r *instrumentUserRepo) teardown() (err error) {
 	defer func(begin time.Time) {
-		r.opObserve(r.store, labelRepoUser, "Teardown", begin, err)
+		r.opObserve(r.store, labelUserRepo, "Teardown", begin, err)
 	}(time.Now())
 
-	return r.next.Teardown()
+	return r.next.teardown()
 }

--- a/pkg/config/postgres.go
+++ b/pkg/config/postgres.go
@@ -13,8 +13,74 @@ import (
 )
 
 const (
-	pgUserCreateSchema = `CREATE SCHEMA IF NOT EXISTS config`
-	pgUserCreateTable  = `
+	pgCreateSchema = `CREATE SCHEMA IF NOT EXISTS config`
+
+	pgBaseCreateTable = `
+		CREATE TABLE IF NOT EXISTS config.bases(
+			client_id TEXT NOT NULL,
+			deleted BOOL DEFAULT FALSE,
+			id TEXT NOT NULL PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			parameters JSONB NOT NULL,
+			created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'utc'),
+			updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'utc')
+		)`
+	pgBaseDropTable = `
+		DROP TABLE IF EXISTS config.bases CASCADE`
+	pgBaseCreate = `
+		/* pgBaseCreate */
+		INSERT INTO
+			config.bases(client_id, id, name, parameters)
+			VALUES(:clientId, :id, :name, :parameters)`
+	pgBaseGetByID = `
+		/* pgBaseGetByID */
+		SELECT
+			client_id, deleted, id, name, parameters, created_at, updated_at
+		FROM
+			config.bases
+		WHERE
+			id = :id
+		ORDER BY
+			created_at DESC
+		LIMIT
+			1`
+	pgBaseGetByName = `
+		/* pgBaseGetByName */
+		SELECT
+			client_id, deleted, id, name, parameters, created_at, updated_at
+		FROM
+			config.bases
+		WHERE
+			client_id = :clientId
+			AND name = :name
+		ORDER BY
+			created_at DESC
+		LIMIT
+			1`
+	pgBaseList = `
+		/* pgBaseList */
+		SELECT
+			client_id, deleted, id, name, parameters, created_at, updated_at
+		FROM
+			config.bases
+		WHERE
+			deleted = :deleted
+		ORDER BY
+			created_at DESC`
+	pgBaseUpdate = `
+		/* pgBaseList */
+		UPDATE
+			config.bases
+		SET
+			deleted = :deleted,
+			name = :name,
+			parameters = :parameters,
+			updated_at = :updatedAt
+		WHERE
+			id = :id
+	`
+
+	pgUserCreateTable = `
 		CREATE TABLE IF NOT EXISTS config.users(
 			id TEXT NOT NULL PRIMARY KEY,
 			user_id TEXT NOT NULL,
@@ -55,15 +121,292 @@ const (
 			config.users(base_id, user_id, created_at DESC)`
 )
 
+type pgBaseRepo struct {
+	db *sqlx.DB
+}
+
+// NewPostgresBaseRepo returns a Postgres backed BaseRepo implementation.
+func NewPostgresBaseRepo(db *sqlx.DB) BaseRepo {
+	return &pgBaseRepo{db: db}
+}
+
+func (r *pgBaseRepo) Create(
+	id, clientID, name string,
+	parameters rendered,
+) (BaseConfig, error) {
+	rawParameters, err := json.Marshal(parameters)
+	if err != nil {
+		return BaseConfig{}, errors.Wrap(err, "marshal parameters")
+	}
+
+	_, err = r.db.NamedExec(pgBaseCreate, map[string]interface{}{
+		"clientId":   clientID,
+		"id":         id,
+		"name":       name,
+		"parameters": rawParameters,
+	})
+	if err != nil {
+		switch errors.Cause(pg.Wrap(err)) {
+		case pg.ErrDuplicateKey:
+			return BaseConfig{}, errors.Wrap(errors.ErrExists, "base config")
+		case pg.ErrRelationNotFound:
+			if err := r.setup(); err != nil {
+				return BaseConfig{}, err
+			}
+
+			return r.Create(id, clientID, name, parameters)
+		default:
+			return BaseConfig{}, fmt.Errorf("named exec: %s", err)
+		}
+	}
+
+	return BaseConfig{
+		ClientID:   clientID,
+		ID:         id,
+		Name:       name,
+		Parameters: parameters,
+		CreatedAt:  time.Now(),
+	}, nil
+}
+
+func (r *pgBaseRepo) GetByID(id string) (BaseConfig, error) {
+	query, args, err := r.db.BindNamed(pgBaseGetByID, map[string]interface{}{
+		"id": id,
+	})
+	if err != nil {
+		return BaseConfig{}, errors.Wrap(err, "named query")
+	}
+
+	raw := struct {
+		ClientID   string    `db:"client_id"`
+		Deleted    bool      `db:"deleted"`
+		ID         string    `db:"id"`
+		Name       string    `db:"name"`
+		Parameters []byte    `db:"parameters"`
+		CreatedAt  time.Time `db:"created_at"`
+		UpdatedAt  time.Time `db:"updated_at"`
+	}{}
+
+	err = r.db.Get(&raw, query, args...)
+	if err != nil {
+		switch errors.Cause(pg.Wrap(err)) {
+		case pg.ErrRelationNotFound:
+			if err := r.setup(); err != nil {
+				return BaseConfig{}, err
+			}
+
+			return r.GetByID(id)
+
+		case sql.ErrNoRows:
+			return BaseConfig{}, errors.Wrap(errors.ErrNotFound, "get base config by id")
+
+		default:
+			return BaseConfig{}, errors.Wrap(err, "get base config by id")
+		}
+	}
+
+	params := rendered{}
+
+	if err := json.Unmarshal(raw.Parameters, &params); err != nil {
+		return BaseConfig{}, errors.Wrap(err, "unmarshal parameters")
+	}
+
+	return BaseConfig{
+		ClientID:   raw.ClientID,
+		ID:         raw.ID,
+		Name:       raw.Name,
+		Parameters: params,
+		CreatedAt:  raw.CreatedAt,
+	}, nil
+}
+
+func (r *pgBaseRepo) GetByName(clientID, name string) (BaseConfig, error) {
+	query, args, err := r.db.BindNamed(pgBaseGetByName, map[string]interface{}{
+		"clientId": clientID,
+		"name":     name,
+	})
+	if err != nil {
+		return BaseConfig{}, errors.Wrap(err, "named query")
+	}
+
+	raw := struct {
+		ClientID   string    `db:"client_id"`
+		Deleted    bool      `db:"deleted"`
+		ID         string    `db:"id"`
+		Name       string    `db:"name"`
+		Parameters []byte    `db:"parameters"`
+		CreatedAt  time.Time `db:"created_at"`
+		UpdatedAt  time.Time `db:"updated_at"`
+	}{}
+
+	err = r.db.Get(&raw, query, args...)
+	if err != nil {
+		switch errors.Cause(pg.Wrap(err)) {
+		case pg.ErrRelationNotFound:
+			if err := r.setup(); err != nil {
+				return BaseConfig{}, err
+			}
+
+			return r.GetByName(clientID, name)
+
+		case sql.ErrNoRows:
+			return BaseConfig{}, errors.Wrap(errors.ErrNotFound, "get base config by id")
+
+		default:
+			return BaseConfig{}, errors.Wrap(err, "get base config by id")
+		}
+	}
+
+	params := rendered{}
+
+	if err := json.Unmarshal(raw.Parameters, &params); err != nil {
+		return BaseConfig{}, errors.Wrap(err, "unmarshal parameters")
+	}
+
+	return BaseConfig{
+		ClientID:   raw.ClientID,
+		ID:         raw.ID,
+		Name:       raw.Name,
+		Parameters: params,
+		CreatedAt:  raw.CreatedAt,
+	}, nil
+}
+
+func (r *pgBaseRepo) List() (BaseList, error) {
+	rows, err := r.db.NamedQuery(pgBaseList, map[string]interface{}{
+		"deleted": false,
+	})
+	if err != nil {
+		switch errors.Cause(pg.Wrap(err)) {
+		case pg.ErrRelationNotFound:
+			if err := r.setup(); err != nil {
+				return nil, err
+			}
+
+			return r.List()
+		default:
+			return nil, errors.Wrap(err, "baseRepo List")
+		}
+	}
+
+	cs := BaseList{}
+
+	for rows.Next() {
+		var (
+			c         = BaseConfig{}
+			rawParams = []byte{}
+		)
+
+		// client_id, deleted, id, name, parameters, created_at, updated_at
+		err := rows.Scan(
+			&c.ClientID,
+			&c.Deleted,
+			&c.ID,
+			&c.Name,
+			&rawParams,
+			&c.CreatedAt,
+			&c.UpdatedAt,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "List scan")
+		}
+
+		if err := json.Unmarshal(rawParams, &c.Parameters); err != nil {
+			return nil, errors.Wrap(err, "unmarshal parameters")
+		}
+
+		cs = append(cs, c)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "List rows")
+	}
+
+	return cs, nil
+}
+
+func (r *pgBaseRepo) Update(c BaseConfig) (BaseConfig, error) {
+	rawParameters, err := json.Marshal(c.Parameters)
+	if err != nil {
+		return BaseConfig{}, errors.Wrap(err, "marshal parameters")
+	}
+
+	updatedAt := time.Now()
+
+	res, err := r.db.NamedExec(pgBaseUpdate, map[string]interface{}{
+		"id":         c.ID,
+		"deleted":    c.Deleted,
+		"name":       c.Name,
+		"parameters": rawParameters,
+		"updatedAt":  updatedAt,
+	})
+	if err != nil {
+		switch errors.Cause(pg.Wrap(err)) {
+		case pg.ErrRelationNotFound:
+			if err := r.setup(); err != nil {
+				return BaseConfig{}, err
+			}
+
+			return r.Update(c)
+		default:
+			return BaseConfig{}, fmt.Errorf("named exec: %s", err)
+		}
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return BaseConfig{}, err
+	}
+
+	if rows == 0 {
+		return BaseConfig{}, errors.Wrapf(errors.ErrNotFound, "id '%s'", c.ID)
+	}
+
+	return BaseConfig{
+		ClientID:   c.ClientID,
+		Deleted:    c.Deleted,
+		ID:         c.ID,
+		Name:       c.Name,
+		Parameters: c.Parameters,
+		CreatedAt:  c.CreatedAt,
+		UpdatedAt:  updatedAt,
+	}, nil
+}
+
+func (r *pgBaseRepo) setup() error {
+	for _, q := range []string{
+		pgCreateSchema,
+		pgBaseCreateTable,
+	} {
+		_, err := r.db.Exec(q)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *pgBaseRepo) teardown() error {
+	for _, q := range []string{
+		pgBaseDropTable,
+	} {
+		_, err := r.db.Exec(q)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 type pgUserRepo struct {
 	db *sqlx.DB
 }
 
 // NewPostgresUserRepo returns a Postgres backed UserRepo implementation.
-func NewPostgresUserRepo(db *sqlx.DB) (UserRepo, error) {
-	return &pgUserRepo{
-		db: db,
-	}, nil
+func NewPostgresUserRepo(db *sqlx.DB) UserRepo {
+	return &pgUserRepo{db: db}
 }
 
 func (r *pgUserRepo) Append(
@@ -93,7 +436,7 @@ func (r *pgUserRepo) Append(
 		case pg.ErrDuplicateKey:
 			return UserConfig{}, errors.Wrap(errors.ErrExists, "user config")
 		case pg.ErrRelationNotFound:
-			if err := r.Setup(); err != nil {
+			if err := r.setup(); err != nil {
 				return UserConfig{}, err
 			}
 
@@ -134,7 +477,7 @@ func (r *pgUserRepo) GetLatest(baseID, userID string) (UserConfig, error) {
 	if err != nil {
 		switch errors.Cause(pg.Wrap(err)) {
 		case pg.ErrRelationNotFound:
-			if err := r.Setup(); err != nil {
+			if err := r.setup(); err != nil {
 				return UserConfig{}, err
 			}
 
@@ -169,9 +512,9 @@ func (r *pgUserRepo) GetLatest(baseID, userID string) (UserConfig, error) {
 	}, nil
 }
 
-func (r *pgUserRepo) Setup() error {
+func (r *pgUserRepo) setup() error {
 	for _, q := range []string{
-		pgUserCreateSchema,
+		pgCreateSchema,
 		pgUserCreateTable,
 		pgUserIndexGetLatest,
 	} {
@@ -184,7 +527,7 @@ func (r *pgUserRepo) Setup() error {
 	return nil
 }
 
-func (r *pgUserRepo) Teardown() error {
+func (r *pgUserRepo) teardown() error {
 	for _, q := range []string{
 		pgUserDropTable,
 	} {

--- a/pkg/config/postgres_test.go
+++ b/pkg/config/postgres_test.go
@@ -17,6 +17,34 @@ import (
 
 var pgURI string
 
+func TestPostgresBaseRepoCreateDuplicate(t *testing.T) {
+	testBaseRepoCreateDuplicate(t, preparePGBaseRepo)
+}
+
+func TestPostgresBaseRepoGetByID(t *testing.T) {
+	testBaseRepoGetByID(t, preparePGBaseRepo)
+}
+
+func TestPostgresBaseRepoGetByIDNotFound(t *testing.T) {
+	testBaseRepoGetByIDNotFound(t, preparePGBaseRepo)
+}
+
+func TestPostgresBaseRepoGetByName(t *testing.T) {
+	testBaseRepoGetByName(t, preparePGBaseRepo)
+}
+
+func TestPostgresBaseRepoGetByNameNotFound(t *testing.T) {
+	testBaseRepoGetByNameNotFound(t, preparePGBaseRepo)
+}
+
+func TestPostgresBaseRepoUpdate(t *testing.T) {
+	testBaseRepoUpdate(t, preparePGBaseRepo)
+}
+
+func TestPostgresBaseRepoList(t *testing.T) {
+	testBaseRepoList(t, preparePGBaseRepo)
+}
+
 func TestPostgresUserRepoGetLatest(t *testing.T) {
 	testUserRepoGetLatest(t, preparePGUserRepo)
 }
@@ -29,18 +57,30 @@ func TestPostgresUserRepoAppendDuplicate(t *testing.T) {
 	testUserRepoAppendDuplicate(t, preparePGUserRepo)
 }
 
+func preparePGBaseRepo(t *testing.T) BaseRepo {
+	db, err := sqlx.Connect("postgres", pgURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewPostgresBaseRepo(db)
+
+	if err := r.teardown(); err != nil {
+		t.Fatal(err)
+	}
+
+	return r
+}
+
 func preparePGUserRepo(t *testing.T) UserRepo {
 	db, err := sqlx.Connect("postgres", pgURI)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	r, err := NewPostgresUserRepo(db)
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewPostgresUserRepo(db)
 
-	if err := r.Teardown(); err != nil {
+	if err := r.teardown(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/config/repo_test.go
+++ b/pkg/config/repo_test.go
@@ -1,21 +1,315 @@
 package config
 
 import (
+	"math/rand"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/oklog/ulid"
 
 	"github.com/lifesum/configsum/pkg/errors"
+	"github.com/lifesum/configsum/pkg/generate"
 )
 
-func testUserRepoGetLatest(t *testing.T, p prepareFunc) {
+type prepareBaseRepoFunc func(t *testing.T) BaseRepo
+
+type prepareUserRepoFunc func(t *testing.T) UserRepo
+
+func testBaseRepoCreateDuplicate(t *testing.T, p prepareBaseRepoFunc) {
+	var (
+		clientID   = generate.RandomString(24)
+		name       = generate.RandomString(12)
+		parameters = rendered{
+			"feature_awesome-sauce_toggle": true,
+		}
+		repo = p(t)
+		seed = rand.New(rand.NewSource(time.Now().UnixNano()))
+	)
+
+	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Create(id.String(), clientID, name, parameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Create(id.String(), clientID, name, parameters)
+	if have, want := errors.Cause(err), errors.ErrExists; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testBaseRepoGetByID(t *testing.T, p prepareBaseRepoFunc) {
+	var (
+		clientID   = generate.RandomString(24)
+		name       = generate.RandomString(12)
+		parameters = rendered{
+			"feature_awesome-sauce_toggle": true,
+		}
+		repo = p(t)
+		seed = rand.New(rand.NewSource(time.Now().UnixNano()))
+	)
+
+	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Create(id.String(), clientID, name, parameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := repo.GetByID(id.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := c.ClientID, clientID; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := c.ID, id.String(); have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := c.Name, name; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := c.Parameters, parameters; !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testBaseRepoGetByIDNotFound(t *testing.T, p prepareBaseRepoFunc) {
+	repo := p(t)
+
+	_, err := repo.GetByID(generate.RandomString(24))
+	if have, want := errors.Cause(err), errors.ErrNotFound; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testBaseRepoGetByName(t *testing.T, p prepareBaseRepoFunc) {
+	var (
+		clientID   = generate.RandomString(24)
+		name       = generate.RandomString(12)
+		parameters = rendered{
+			"feature_awesome-sauce_toggle": true,
+		}
+		repo = p(t)
+		seed = rand.New(rand.NewSource(time.Now().UnixNano()))
+	)
+
+	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Create(id.String(), clientID, name, parameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := repo.GetByName(clientID, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := c.ClientID, clientID; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := c.ID, id.String(); have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := c.Name, name; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := c.Parameters, parameters; !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testBaseRepoGetByNameNotFound(t *testing.T, p prepareBaseRepoFunc) {
+	var (
+		clientID = generate.RandomString(24)
+		name     = generate.RandomString(12)
+		repo     = p(t)
+	)
+
+	_, err := repo.GetByName(clientID, name)
+	if have, want := errors.Cause(err), errors.ErrNotFound; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testBaseRepoList(t *testing.T, p prepareBaseRepoFunc) {
+	var (
+		repo       = p(t)
+		seed       = rand.New(rand.NewSource(time.Now().UnixNano()))
+		numConfigs = seed.Intn(24)
+
+		es = BaseList{}
+	)
+
+	for i := 0; i < numConfigs; i++ {
+		var (
+			clientID   = generate.RandomString(24)
+			name       = generate.RandomString(12)
+			parameters = rendered{
+				generate.RandomString(8):  false,
+				generate.RandomString(12): float64(seed.Intn(64)),
+				generate.RandomString(16): generate.RandomString(24),
+			}
+		)
+
+		id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		c, err := repo.Create(id.String(), clientID, name, parameters)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		es = append(es, c)
+	}
+
+	cs, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := len(cs), numConfigs; have != want {
+		t.Fatalf("have %v, want %v", have, want)
+	}
+
+	sort.Sort(es)
+
+	for i, expect := range es {
+		c := cs[i]
+
+		if have, want := c.ClientID, expect.ClientID; have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+
+		if have, want := c.ID, expect.ID; have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+
+		if have, want := c.Name, expect.Name; have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+
+		if have, want := c.Parameters, expect.Parameters; !reflect.DeepEqual(have, want) {
+			t.Errorf("\nhave %#v\nwant %#v", have, want)
+		}
+	}
+}
+
+func testBaseRepoUpdate(t *testing.T, p prepareBaseRepoFunc) {
+	var (
+		clientID   = generate.RandomString(24)
+		name       = generate.RandomString(12)
+		parameters = rendered{
+			"feature_awesome-sauce_toggle": true,
+		}
+		repo = p(t)
+		seed = rand.New(rand.NewSource(time.Now().UnixNano()))
+	)
+
+	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Update(BaseConfig{ID: id.String()})
+	if have, want := errors.Cause(err), errors.ErrNotFound; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	c, err := repo.Create(id.String(), clientID, name, parameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newParams := rendered{
+		"feature_awesome-sauce_toggle": true,
+		"feature_awesome-sauce_desc":   generate.RandomString(24),
+	}
+
+	_, err = repo.Update(BaseConfig{
+		ClientID:   clientID,
+		Deleted:    false,
+		ID:         id.String(),
+		Name:       name,
+		Parameters: newParams,
+		CreatedAt:  c.CreatedAt,
+		UpdatedAt:  c.UpdatedAt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = repo.GetByID(id.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := c.Parameters, newParams; !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testUserRepoAppendDuplicate(t *testing.T, p prepareUserRepoFunc) {
 	var (
 		baseID    = randString(characterSet)
 		userID    = randString(numCharacterSet)
 		render    = rendered{}
 		repo      = p(t)
+		seed      = rand.New(rand.NewSource(time.Now().UnixNano()))
+		decisions = ruleDecisions{
+			randString(numCharacterSet): []int{seed.Int(), seed.Int()},
+			randString(numCharacterSet): []int{seed.Int()},
+			randString(numCharacterSet): []int{},
+		}
+	)
+
+	render.SetBool(randString(numCharacterSet), false)
+
+	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Append(id.String(), baseID, userID, decisions, render)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Append(id.String(), baseID, userID, decisions, render)
+	if have, want := errors.Cause(err), errors.ErrExists; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testUserRepoGetLatest(t *testing.T, p prepareUserRepoFunc) {
+	var (
+		baseID    = randString(characterSet)
+		userID    = randString(numCharacterSet)
+		render    = rendered{}
+		repo      = p(t)
+		seed      = rand.New(rand.NewSource(time.Now().UnixNano()))
 		decisions = ruleDecisions{
 			randString(numCharacterSet): []int{seed.Intn(100), seed.Intn(100)},
 			randString(numCharacterSet): []int{seed.Intn(100)},
@@ -83,7 +377,7 @@ func testUserRepoGetLatest(t *testing.T, p prepareFunc) {
 	}
 }
 
-func testUserRepoGetLatestNotFound(t *testing.T, p prepareFunc) {
+func testUserRepoGetLatestNotFound(t *testing.T, p prepareUserRepoFunc) {
 	var (
 		baseID = randString(characterSet)
 		userID = randString(numCharacterSet)
@@ -92,37 +386,6 @@ func testUserRepoGetLatestNotFound(t *testing.T, p prepareFunc) {
 
 	_, err := repo.GetLatest(baseID, userID)
 	if have, want := errors.Cause(err), errors.ErrNotFound; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-}
-
-func testUserRepoAppendDuplicate(t *testing.T, p prepareFunc) {
-	var (
-		baseID    = randString(characterSet)
-		userID    = randString(numCharacterSet)
-		render    = rendered{}
-		repo      = p(t)
-		decisions = ruleDecisions{
-			randString(numCharacterSet): []int{seed.Int(), seed.Int()},
-			randString(numCharacterSet): []int{seed.Int()},
-			randString(numCharacterSet): []int{},
-		}
-	)
-
-	render.SetBool(randString(numCharacterSet), false)
-
-	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = repo.Append(id.String(), baseID, userID, decisions, render)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = repo.Append(id.String(), baseID, userID, decisions, render)
-	if have, want := errors.Cause(err), errors.ErrExists; have != want {
 		t.Errorf("have %v, want %v", have, want)
 	}
 }

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -2,10 +2,62 @@ package config
 
 import "github.com/xeipuuv/gojsonschema"
 
-const requestCapabilities = `
+const schemaDefBaseCreate = `
+{
+  "$schema":"http://json-schema.org/draft-06/schema#",
+  "title":"Base update",
+  "description":"Request data for base config updates.",
+  "type":"object",
+  "required":[
+    "client_id", "name"
+  ],
+  "properties": {
+    "client_id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    }
+  }
+}`
+
+const schemaDefBaseUpdate = `
+{
+  "$schema":"http://json-schema.org/draft-06/schema#",
+  "title":"Base update",
+  "description":"Request data for base config updates.",
+  "type":"object",
+  "required":[
+    "parameters"
+  ],
+  "properties":{
+    "parameters":{
+      "type":"object",
+      "additionalProperties":false,
+      "minProperties":1,
+      "patternProperties":{
+        "^feature_([a-z-]+)_([a-z]+)$":{
+          "anyOf":[
+            {
+              "type":"boolean"
+            },
+            {
+              "type":"number"
+            },
+            {
+              "type":"string"
+            }
+          ]
+        }
+      }
+    }
+  }
+}`
+
+const schemaDefUserRender = `
 {
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Client payload",
+  "title": "Render context",
   "description": "Common set of information to determine device capabilities and user provided info.",
   "type": "object",
   "properties": {
@@ -109,12 +161,31 @@ const requestCapabilities = `
   ]
 }`
 
-var decodeClientPayloadSchema *gojsonschema.Schema
+var (
+	schemaBaseCreateRequest *gojsonschema.Schema
+	schemaBaseUpdateRequest *gojsonschema.Schema
+	schemaUserRenderRequest *gojsonschema.Schema
+)
 
 func init() {
 	var err error
 
-	decodeClientPayloadSchema, err = gojsonschema.NewSchema(gojsonschema.NewStringLoader(requestCapabilities))
+	schemaBaseCreateRequest, err = gojsonschema.NewSchema(
+		gojsonschema.NewStringLoader(schemaDefBaseCreate),
+	)
+	if err != nil {
+	}
+
+	schemaBaseUpdateRequest, err = gojsonschema.NewSchema(
+		gojsonschema.NewStringLoader(schemaDefBaseUpdate),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	schemaUserRenderRequest, err = gojsonschema.NewSchema(
+		gojsonschema.NewStringLoader(schemaDefUserRender),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/config/schema_test.go
+++ b/pkg/config/schema_test.go
@@ -6,56 +6,92 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-var (
-	schema            = gojsonschema.NewStringLoader(requestCapabilities)
-	testFailingInputs = []string{
-		`{}`,                                                                                                                                // App missing
-		`{"app": {}}`,                                                                                                                       // Empty App object
-		`{"app": {"version": "6.4.1"}}`,                                                                                                     // Device missing
-		`{"app": {"version": "6.4.1"}, "device": {}, "os": {"platform": "WatchOS", "version": "9.4"}}`,                                      // Empty Device object
-		`{"app": {"version": "6.4.1"}, "device": {"location": {}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,                        // Empty Location object
-		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB"}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,       // TimezoneOffset missing
-		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}}}`,                                // OS missing
-		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}, "os": {}}}`,                      // Empty Os object
-		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}, "os": {"platform": "WatchOS"}}}`, // Version missing
+func TestSchemaBaseCreateInvalid(t *testing.T) {
+	cases := []string{
+		`{}`, // Empty.
+		`{"client_id": "clientID"}`,  // Name missing,
+		`{"name": "baseConfigName"}`, // ClientID missing.
 	}
-	testSuccessInputs = []string{
-		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {"age": 23}}`,                   // Working case
-		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {}}`,                            // User age optional
-		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {"age": 27}}`,                      // Only region provided
-		`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7201}, "metadata": null, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {"age": 23}}`, // Metadata value is null
-	}
-)
 
-func TestPayloadValidationFailure(t *testing.T) {
-	want := "invalid JSON error"
-
-	for _, input := range testFailingInputs {
-		json := gojsonschema.NewStringLoader(input)
-
-		result, err := gojsonschema.Validate(schema, json)
+	for _, c := range cases {
+		r, err := schemaBaseCreateRequest.Validate(gojsonschema.NewStringLoader(c))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if result.Valid() {
+		if r.Valid() {
+			t.Errorf("invalid: %s", c)
+		}
+	}
+}
+
+func TestSchemaBaseUpdateInvalid(t *testing.T) {
+	cases := []string{
+		`{}`,                                                      // Missing parameters.
+		`{"parameters": {}}`,                                      // Empty parameters.
+		`{"parameters": {"feature_array_toggled": {}} }`,          // Array as parameter type.
+		`{"parameters": {"feature_object_toggled": []} }`,         // Object as parameter type.
+		`{"parameters": {"feature_inv4l1d$char_toggled": true} }`, // Invalid character in parameter key.
+	}
+
+	for _, input := range cases {
+		res, err := schemaBaseUpdateRequest.Validate(gojsonschema.NewStringLoader(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res.Valid() {
+			t.Errorf("invalid: %s", input)
+		}
+	}
+}
+
+func TestSchemaUserRenderInvalid(t *testing.T) {
+	var (
+		want  = "invalid JSON error"
+		cases = []string{
+			`{}`,                                                                                                                                // App missing
+			`{"app": {}}`,                                                                                                                       // Empty App object
+			`{"app": {"version": "6.4.1"}}`,                                                                                                     // Device missing
+			`{"app": {"version": "6.4.1"}, "device": {}, "os": {"platform": "WatchOS", "version": "9.4"}}`,                                      // Empty Device object
+			`{"app": {"version": "6.4.1"}, "device": {"location": {}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,                        // Empty Location object
+			`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB"}, "os": {"platform": "WatchOS", "version": "9.4"}}}`,       // TimezoneOffset missing
+			`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}}}`,                                // OS missing
+			`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}, "os": {}}}`,                      // Empty Os object
+			`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7200}, "os": {"platform": "WatchOS"}}}`, // Version missing
+		}
+	)
+
+	for _, input := range cases {
+		res, err := schemaUserRenderRequest.Validate(gojsonschema.NewStringLoader(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res.Valid() {
 			t.Errorf("have %v, want %v", input, want)
 		}
 	}
 }
 
-func TestPayloadValidationSuccess(t *testing.T) {
-	want := "valid JSON input"
+func TestSchemaUserRenderValid(t *testing.T) {
+	var (
+		want  = "valid JSON input"
+		cases = []string{
+			`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {"age": 23}}`,                   // Working case
+			`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {}}`,                            // User age optional
+			`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en", "timezoneOffset": 7201}, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {"age": 27}}`,                      // Only region provided
+			`{"app": {"version": "6.4.1"}, "device": {"location": {"locale": "en_GB", "timezoneOffset": 7201}, "metadata": null, "os": {"platform": "WatchOS", "version": "9.4"}}, "user": {"age": 23}}`, // Metadata value is null
+		}
+	)
 
-	for _, input := range testSuccessInputs {
-		json := gojsonschema.NewStringLoader(input)
-
-		result, err := gojsonschema.Validate(schema, json)
+	for _, input := range cases {
+		res, err := schemaUserRenderRequest.Validate(gojsonschema.NewStringLoader(input))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if !result.Valid() {
+		if !res.Valid() {
 			t.Errorf("have %v, want %v", input, want)
 		}
 	}

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -7,31 +7,104 @@ import (
 
 	"github.com/oklog/ulid"
 
+	"github.com/lifesum/configsum/pkg/client"
 	"github.com/lifesum/configsum/pkg/errors"
 )
 
-// ServiceUser provides user specific configs.
-type ServiceUser interface {
+// BaseService provides base configs.
+type BaseService interface {
+	Create(clientID, name string) (BaseConfig, error)
+	Get(id string) (BaseConfig, error)
+	List() ([]BaseConfig, error)
+	Update(id string, parameters rendered) (BaseConfig, error)
+}
+
+type baseService struct {
+	baseRepo   BaseRepo
+	clientRepo client.Repo
+	seed       *rand.Rand
+}
+
+// NewBaseService provides base configs.
+func NewBaseService(baseRepo BaseRepo, clientRepo client.Repo) BaseService {
+	return &baseService{
+		baseRepo:   baseRepo,
+		clientRepo: clientRepo,
+		seed:       rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+func (s *baseService) Create(clientID, name string) (BaseConfig, error) {
+	id, err := ulid.New(ulid.Timestamp(time.Now()), s.seed)
+	if err != nil {
+		return BaseConfig{}, errors.Wrap(errors.ErrID, err.Error())
+	}
+
+	_, err = s.clientRepo.Lookup(clientID)
+	if err != nil {
+		return BaseConfig{}, err
+	}
+
+	return s.baseRepo.Create(id.String(), clientID, name, nil)
+}
+
+func (s *baseService) Get(id string) (BaseConfig, error) {
+	return s.baseRepo.GetByID(id)
+}
+
+func (s *baseService) List() ([]BaseConfig, error) {
+	cs, err := s.baseRepo.List()
+	if err != nil {
+		return nil, err
+	}
+
+	return cs, nil
+}
+
+func (s *baseService) Update(id string, params rendered) (BaseConfig, error) {
+	bc, err := s.baseRepo.GetByID(id)
+	if err != nil {
+		return BaseConfig{}, err
+	}
+
+	err = validateParamDelta(bc.Parameters, params)
+	if err != nil {
+		return BaseConfig{}, err
+	}
+
+	return s.baseRepo.Update(BaseConfig{
+		ClientID:   bc.ClientID,
+		Deleted:    bc.Deleted,
+		ID:         bc.ID,
+		Name:       bc.Name,
+		Parameters: params,
+		CreatedAt:  bc.CreatedAt,
+		UpdatedAt:  bc.UpdatedAt,
+	})
+}
+
+// UserService provides user specific configs.
+type UserService interface {
 	Render(clientID, baseName, userID string) (UserConfig, error)
 }
 
-type serviceUser struct {
+type userService struct {
 	baseRepo BaseRepo
 	userRepo UserRepo
 	seed     *rand.Rand
 }
 
-// NewServiceUser provides user specific configs.
-func NewServiceUser(baseRepo BaseRepo, userRepo UserRepo) ServiceUser {
-	return &serviceUser{
+// NewUserService provides user specific configs.
+func NewUserService(baseRepo BaseRepo, userRepo UserRepo) UserService {
+	return &userService{
 		baseRepo: baseRepo,
 		userRepo: userRepo,
 		seed:     rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
-func (s *serviceUser) Render(clientID, baseName, userID string) (UserConfig, error) {
-	bc, err := s.baseRepo.Get(clientID, baseName)
+func (s *userService) Render(clientID, baseName, userID string) (UserConfig, error) {
+	bc, err := s.baseRepo.GetByName(clientID, baseName)
 	if err != nil {
 		return UserConfig{}, errors.Wrap(err, "baseRepo.Get")
 	}
@@ -48,7 +121,7 @@ func (s *serviceUser) Render(clientID, baseName, userID string) (UserConfig, err
 
 	// TODO(nabilm): Create temp config with rules applied
 
-	if reflect.DeepEqual(bc.Rendered, uc.rendered) {
+	if reflect.DeepEqual(bc.Parameters, uc.rendered) {
 		return uc, nil
 	}
 
@@ -57,5 +130,30 @@ func (s *serviceUser) Render(clientID, baseName, userID string) (UserConfig, err
 		return UserConfig{}, errors.Wrap(err, "create ulid")
 	}
 
-	return s.userRepo.Append(id.String(), bc.ID, userID, nil, bc.Rendered)
+	return s.userRepo.Append(id.String(), bc.ID, userID, nil, bc.Parameters)
+}
+
+// validateParamDelta given a base and the new version of the parameters
+// returns an error if:
+// * a key from base is missing in the new version
+// * the type of a key was changed
+func validateParamDelta(base, new rendered) error {
+	for key, val := range base {
+		v, ok := new[key]
+		if !ok {
+			return errors.Wrapf(errors.ErrParametersInvalid, "key missing '%s'", key)
+		}
+
+		if reflect.TypeOf(val).Kind() != reflect.TypeOf(v).Kind() {
+			return errors.Wrapf(
+				errors.ErrParametersInvalid,
+				"value for '%s' missmatch '%s' != '%s'",
+				key,
+				reflect.TypeOf(val).Kind(),
+				reflect.TypeOf(v).Kind(),
+			)
+		}
+	}
+
+	return nil
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -6,6 +6,7 @@ import (
 
 // Entity errors.
 var (
+	ErrID       = errors.New("id creation")
 	ErrExists   = errors.New("entity exists")
 	ErrNotFound = errors.New("entity not found")
 )
@@ -17,6 +18,11 @@ var (
 	ErrSignatureMissing   = errors.New("signature missing")
 	ErrSignatureMissmatch = errors.New("signature missmatch")
 	ErrUserIDMissing      = errors.New("userID missing")
+)
+
+// Config errors.
+var (
+	ErrParametersInvalid = errors.New("parameters invalid")
 )
 
 // Transport errors.

--- a/pkg/transport/http/transport.go
+++ b/pkg/transport/http/transport.go
@@ -37,7 +37,7 @@ func ErrorEncoder(_ context.Context, err error, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusUnauthorized)
 	case errors.ErrSignatureMissing, errors.ErrSignatureMissmatch, errors.ErrUserIDMissing:
 		w.WriteHeader(http.StatusUnauthorized)
-	case errors.ErrInvalidPayload:
+	case errors.ErrInvalidPayload, errors.ErrParametersInvalid:
 		w.WriteHeader(http.StatusBadRequest)
 	default:
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
So far we limited use of base configs to in-memory retrieval. This change completes the implementation with a Postgres backed repo and a variety of endpoints to create and change configs.

* implement postgres backed BaseRepo
* create, get, list and update endpoints
* guard endppints with json schemas
* represent parameters as list for easier client handling
* extend BaseRepo interface
* adjust naming of user config components to reduce ambiguity and
stutter