### PR TITLE
Integrate rules in user config rendering

### DIFF
--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lifesum/configsum/pkg/auth"
 	"github.com/lifesum/configsum/pkg/client"
 	"github.com/lifesum/configsum/pkg/errors"
+	"github.com/lifesum/configsum/pkg/rule"
 )
 
 type baseCreateRequest struct {
@@ -154,7 +155,7 @@ func baseListEndpoint(svc BaseService) endpoint.Endpoint {
 
 type baseUpdateRequest struct {
 	id         string
-	parameters rendered
+	parameters rule.Parameters
 }
 
 func baseUpdateEndpoint(svc BaseService) endpoint.Endpoint {
@@ -211,7 +212,7 @@ type userRenderResponse struct {
 	baseName  string
 	clientID  string
 	id        string
-	rendered  rendered
+	rendered  rule.Parameters
 	createdAt time.Time
 }
 
@@ -227,7 +228,7 @@ func userRenderEndpoint(svc UserService) endpoint.Endpoint {
 			userID   = ctx.Value(auth.ContextKeyUserID).(string)
 		)
 
-		c, err := svc.Render(clientID, req.baseConfig, userID)
+		c, err := svc.Render(clientID, req.baseConfig, userID, req.context)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/config/inmem.go
+++ b/pkg/config/inmem.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/lifesum/configsum/pkg/errors"
+
+	"github.com/lifesum/configsum/pkg/rule"
 )
 
 // InmemBaseState is a container to pass initial state for the inmem repo.
@@ -28,7 +30,7 @@ func NewInmemBaseRepo(initial InmemBaseState) BaseRepo {
 
 func (s *inmemBaseRepo) Create(
 	id, clientID, name string,
-	parameters rendered,
+	parameters rule.Parameters,
 ) (BaseConfig, error) {
 	_, ok := s.configs[clientID]
 	if !ok {
@@ -144,8 +146,8 @@ func NewInmemUserRepo() UserRepo {
 
 func (r *inmemUserRepo) Append(
 	id, baseID, userID string,
-	decisions ruleDecisions,
-	render rendered,
+	decisions rule.Decisions,
+	render rule.Parameters,
 ) (UserConfig, error) {
 	if _, ok := r.ids[id]; ok {
 		return UserConfig{}, errors.Wrap(errors.ErrExists, "id")

--- a/pkg/config/instrument.go
+++ b/pkg/config/instrument.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lifesum/configsum/pkg/instrument"
+	"github.com/lifesum/configsum/pkg/rule"
 )
 
 const (
@@ -34,7 +35,7 @@ func NewBaseRepoInstrumentMiddleware(
 
 func (r *instrumentBaseRepo) Create(
 	id, clientID, name string,
-	parameters rendered,
+	parameters rule.Parameters,
 ) (c BaseConfig, err error) {
 	defer func(begin time.Time) {
 		r.opObserve(r.store, labelBaseRepo, "Create", begin, err)
@@ -114,8 +115,8 @@ func NewUserRepoInstrumentMiddleware(
 
 func (r *instrumentUserRepo) Append(
 	id, baseID, userID string,
-	decisions ruleDecisions,
-	render rendered,
+	decisions rule.Decisions,
+	render rule.Parameters,
 ) (c UserConfig, err error) {
 	defer func(begin time.Time) {
 		r.opObserve(r.store, labelUserRepo, "Append", begin, err)

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+
+	"github.com/lifesum/configsum/pkg/rule"
 )
 
 // Log fields.
@@ -47,7 +49,7 @@ func NewBaseRepoLogMiddleware(logger log.Logger, store string) BaseRepoMiddlewar
 
 func (r *logBaseRepo) Create(
 	id, clientID, name string,
-	parameters rendered,
+	parameters rule.Parameters,
 ) (c BaseConfig, err error) {
 	defer func(begin time.Time) {
 		ps := []interface{}{
@@ -197,8 +199,8 @@ func NewUserRepoLogMiddleware(logger log.Logger, store string) UserRepoMiddlewar
 
 func (r *logUserRepo) Append(
 	id, baseID, userID string,
-	decisions ruleDecisions,
-	render rendered,
+	decisions rule.Decisions,
+	render rule.Parameters,
 ) (c UserConfig, err error) {
 	defer func(begin time.Time) {
 		ps := []interface{}{

--- a/pkg/config/postgres.go
+++ b/pkg/config/postgres.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lifesum/configsum/pkg/errors"
 	"github.com/lifesum/configsum/pkg/pg"
+	"github.com/lifesum/configsum/pkg/rule"
 )
 
 const (
@@ -131,7 +132,7 @@ func NewPostgresBaseRepo(db *sqlx.DB) BaseRepo {
 
 func (r *pgBaseRepo) Create(
 	id, clientID, name string,
-	parameters rendered,
+	parameters rule.Parameters,
 ) (BaseConfig, error) {
 	rawParameters, err := json.Marshal(parameters)
 	if err != nil {
@@ -204,7 +205,7 @@ func (r *pgBaseRepo) GetByID(id string) (BaseConfig, error) {
 		}
 	}
 
-	params := rendered{}
+	params := rule.Parameters{}
 
 	if err := json.Unmarshal(raw.Parameters, &params); err != nil {
 		return BaseConfig{}, errors.Wrap(err, "unmarshal parameters")
@@ -257,7 +258,7 @@ func (r *pgBaseRepo) GetByName(clientID, name string) (BaseConfig, error) {
 		}
 	}
 
-	params := rendered{}
+	params := rule.Parameters{}
 
 	if err := json.Unmarshal(raw.Parameters, &params); err != nil {
 		return BaseConfig{}, errors.Wrap(err, "unmarshal parameters")
@@ -411,8 +412,8 @@ func NewPostgresUserRepo(db *sqlx.DB) UserRepo {
 
 func (r *pgUserRepo) Append(
 	id, baseID, userID string,
-	decisions ruleDecisions,
-	render rendered,
+	decisions rule.Decisions,
+	render rule.Parameters,
 ) (UserConfig, error) {
 	rawRendered, err := json.Marshal(render)
 	if err != nil {
@@ -490,13 +491,13 @@ func (r *pgUserRepo) GetLatest(baseID, userID string) (UserConfig, error) {
 		}
 	}
 
-	render := rendered{}
+	render := rule.Parameters{}
 
 	if err := json.Unmarshal(raw.Rendered, &render); err != nil {
 		return UserConfig{}, errors.Wrap(err, "unmarshal rendered")
 	}
 
-	decisions := ruleDecisions{}
+	decisions := rule.Decisions{}
 
 	if err := json.Unmarshal(raw.RuleDecisions, &decisions); err != nil {
 		return UserConfig{}, errors.Wrap(err, "unmarshal decisons")

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -2,13 +2,15 @@ package config
 
 import (
 	"time"
+
+	"github.com/lifesum/configsum/pkg/rule"
 )
 
 // BaseRepo provides access to base configs.
 type BaseRepo interface {
 	lifecycle
 
-	Create(id, clientID, name string, parameters rendered) (BaseConfig, error)
+	Create(id, clientID, name string, parameters rule.Parameters) (BaseConfig, error)
 	GetByID(id string) (BaseConfig, error)
 	GetByName(clientID, name string) (BaseConfig, error)
 	List() (BaseList, error)
@@ -24,7 +26,7 @@ type BaseConfig struct {
 	Deleted    bool
 	ID         string
 	Name       string
-	Parameters rendered
+	Parameters rule.Parameters
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 }
@@ -44,40 +46,14 @@ func (l BaseList) Swap(i, j int) {
 	l[i], l[j] = l[j], l[i]
 }
 
-type rendered map[string]interface{}
-
-func (r rendered) SetBool(key string, value bool) {
-	r[key] = value
-}
-
-func (r rendered) setNumber(key string, value float64) {
-	r[key] = value
-}
-
-func (r rendered) setNumberList(key string, value []float64) {
-	r[key] = value
-}
-
-func (r rendered) setString(key, value string) {
-	r[key] = value
-}
-
-func (r rendered) setStringList(key string, value []string) {
-	r[key] = value
-}
-
-// ruleDecisions reflects a matrix of rules applied to a config and if present
-// the results of dice rolls for percenatage based decisions.
-type ruleDecisions map[string][]int
-
 // UserRepo provides access to user configs.
 type UserRepo interface {
 	lifecycle
 
 	Append(
 		id, baseID, userID string,
-		decisiosn ruleDecisions,
-		render rendered,
+		decisiosn rule.Decisions,
+		render rule.Parameters,
 	) (UserConfig, error)
 	GetLatest(baseID, userID string) (UserConfig, error)
 }
@@ -89,8 +65,8 @@ type UserRepoMiddleware func(UserRepo) UserRepo
 type UserConfig struct {
 	baseID        string
 	id            string
-	rendered      rendered
-	ruleDecisions ruleDecisions
+	rendered      rule.Parameters
+	ruleDecisions rule.Decisions
 	userID        string
 	createdAt     time.Time
 }

--- a/pkg/config/repo_test.go
+++ b/pkg/config/repo_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lifesum/configsum/pkg/errors"
 	"github.com/lifesum/configsum/pkg/generate"
+	"github.com/lifesum/configsum/pkg/rule"
 )
 
 type prepareBaseRepoFunc func(t *testing.T) BaseRepo
@@ -21,7 +22,7 @@ func testBaseRepoCreateDuplicate(t *testing.T, p prepareBaseRepoFunc) {
 	var (
 		clientID   = generate.RandomString(24)
 		name       = generate.RandomString(12)
-		parameters = rendered{
+		parameters = rule.Parameters{
 			"feature_awesome-sauce_toggle": true,
 		}
 		repo = p(t)
@@ -48,7 +49,7 @@ func testBaseRepoGetByID(t *testing.T, p prepareBaseRepoFunc) {
 	var (
 		clientID   = generate.RandomString(24)
 		name       = generate.RandomString(12)
-		parameters = rendered{
+		parameters = rule.Parameters{
 			"feature_awesome-sauce_toggle": true,
 		}
 		repo = p(t)
@@ -100,7 +101,7 @@ func testBaseRepoGetByName(t *testing.T, p prepareBaseRepoFunc) {
 	var (
 		clientID   = generate.RandomString(24)
 		name       = generate.RandomString(12)
-		parameters = rendered{
+		parameters = rule.Parameters{
 			"feature_awesome-sauce_toggle": true,
 		}
 		repo = p(t)
@@ -165,7 +166,7 @@ func testBaseRepoList(t *testing.T, p prepareBaseRepoFunc) {
 		var (
 			clientID   = generate.RandomString(24)
 			name       = generate.RandomString(12)
-			parameters = rendered{
+			parameters = rule.Parameters{
 				generate.RandomString(8):  false,
 				generate.RandomString(12): float64(seed.Intn(64)),
 				generate.RandomString(16): generate.RandomString(24),
@@ -221,7 +222,7 @@ func testBaseRepoUpdate(t *testing.T, p prepareBaseRepoFunc) {
 	var (
 		clientID   = generate.RandomString(24)
 		name       = generate.RandomString(12)
-		parameters = rendered{
+		parameters = rule.Parameters{
 			"feature_awesome-sauce_toggle": true,
 		}
 		repo = p(t)
@@ -243,7 +244,7 @@ func testBaseRepoUpdate(t *testing.T, p prepareBaseRepoFunc) {
 		t.Fatal(err)
 	}
 
-	newParams := rendered{
+	newParams := rule.Parameters{
 		"feature_awesome-sauce_toggle": true,
 		"feature_awesome-sauce_desc":   generate.RandomString(24),
 	}
@@ -273,19 +274,19 @@ func testBaseRepoUpdate(t *testing.T, p prepareBaseRepoFunc) {
 
 func testUserRepoGetLatest(t *testing.T, p prepareUserRepoFunc) {
 	var (
-		baseID    = generate.RandomString(24)
-		userID    = generate.RandomString(24)
-		render    = rendered{}
+		baseID = generate.RandomString(24)
+		userID = generate.RandomString(24)
+		seed   = rand.New(rand.NewSource(time.Now().UnixNano()))
+		render = rule.Parameters{
+			generate.RandomString(24): seed.Float64(),
+		}
 		repo      = p(t)
-		seed      = rand.New(rand.NewSource(time.Now().UnixNano()))
-		decisions = ruleDecisions{
+		decisions = rule.Decisions{
 			generate.RandomString(24): []int{seed.Intn(100), seed.Intn(100)},
 			generate.RandomString(24): []int{seed.Intn(100)},
 			generate.RandomString(24): []int{},
 		}
 	)
-
-	render.setNumber(generate.RandomString(24), seed.Float64())
 
 	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
 	if err != nil {
@@ -308,7 +309,7 @@ func testUserRepoGetLatest(t *testing.T, p prepareUserRepoFunc) {
 		baseID,
 		userID,
 		nil,
-		rendered{},
+		rule.Parameters{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -360,19 +361,19 @@ func testUserRepoGetLatestNotFound(t *testing.T, p prepareUserRepoFunc) {
 
 func testUserRepoAppendDuplicate(t *testing.T, p prepareUserRepoFunc) {
 	var (
-		baseID    = generate.RandomString(24)
-		userID    = generate.RandomString(24)
-		render    = rendered{}
+		baseID = generate.RandomString(24)
+		userID = generate.RandomString(24)
+		render = rule.Parameters{
+			generate.RandomString(24): false,
+		}
 		repo      = p(t)
 		seed      = rand.New(rand.NewSource(time.Now().UnixNano()))
-		decisions = ruleDecisions{
+		decisions = rule.Decisions{
 			generate.RandomString(32): []int{seed.Int(), seed.Int()},
 			generate.RandomString(32): []int{seed.Int()},
 			generate.RandomString(32): []int{},
 		}
 	)
-
-	render.SetBool(generate.RandomString(24), false)
 
 	id, err := ulid.New(ulid.Timestamp(time.Now()), seed)
 	if err != nil {

--- a/pkg/config/transport.go
+++ b/pkg/config/transport.go
@@ -14,6 +14,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/lifesum/configsum/pkg/errors"
+	"github.com/lifesum/configsum/pkg/rule"
 )
 
 // Headers.
@@ -191,7 +192,7 @@ func decodeBaseUpdateRequest(ctx context.Context, r *http.Request) (interface{},
 	}
 
 	v := struct {
-		Parameters rendered `json:"parameters"`
+		Parameters rule.Parameters `json:"parameters"`
 	}{}
 
 	err := json.NewDecoder(r.Body).Decode(&v)

--- a/pkg/config/transport_test.go
+++ b/pkg/config/transport_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/lifesum/configsum/pkg/errors"
 	"github.com/lifesum/configsum/pkg/generate"
+	"github.com/lifesum/configsum/pkg/rule"
 )
 
 const (
@@ -119,7 +120,7 @@ func TestDecodeBaseUpdateRequest(t *testing.T) {
 
 	want := baseUpdateRequest{
 		id: id.String(),
-		parameters: rendered{
+		parameters: rule.Parameters{
 			"feature_decode_toggled": true,
 		},
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -37,6 +37,7 @@ var (
 	ErrInvalidTypeToMatch = errors.New("invalid input type")
 	ErrNoRuleForID        = errors.New("no rules for this ID")
 	ErrNoRuleWithName     = errors.New("no rule with name")
+	ErrRuleNoMatch        = errors.New("no match")
 )
 
 // Cause is a wraper over github.com/pkg/errors.Cause.

--- a/pkg/rule/criteria.go
+++ b/pkg/rule/criteria.go
@@ -14,14 +14,21 @@ const (
 	comparatorIN
 )
 
-type comparator int8
-
-type criteria struct {
-	User *criteriaUser
-}
-
 type matcher interface {
 	match(input interface{}) (bool, error)
+}
+
+type comparator int8
+
+// Criteria defines if a rule will match on the given context data.
+type Criteria struct {
+	User *CriteriaUser
+}
+
+// CriteriaUser holds all relevant matchers concerning a user.
+type CriteriaUser struct {
+	Age *matcher
+	ID  *MatcherStringList
 }
 
 type matcherBool struct {
@@ -43,26 +50,19 @@ type matcherListInt struct {
 	value []int
 }
 
-type matcherListString struct {
-	Value []string
-}
+type MatcherStringList []string
 
-func (m matcherListString) match(input interface{}) (bool, error) {
+func (m MatcherStringList) match(input interface{}) (bool, error) {
 	t, ok := input.(string)
 	if !ok {
 		return false, errors.Wrapf(errors.ErrInvalidTypeToMatch, "missmatch %s != string", reflect.TypeOf(input).Kind())
 	}
 
-	for _, v := range m.Value {
+	for _, v := range m {
 		if t == v {
 			return true, nil
 		}
 	}
 
 	return false, nil
-}
-
-type criteriaUser struct {
-	Age *matcher
-	ID  *matcherListString
 }

--- a/pkg/rule/criteria_test.go
+++ b/pkg/rule/criteria_test.go
@@ -21,9 +21,7 @@ func TestMatcherListString(t *testing.T) {
 		}
 	)
 
-	m := matcherListString{
-		Value: goodVals,
-	}
+	m := MatcherStringList(goodVals)
 
 	ok, err := m.match(input)
 	if err != nil {
@@ -34,9 +32,7 @@ func TestMatcherListString(t *testing.T) {
 		t.Errorf("expect input to match")
 	}
 
-	m = matcherListString{
-		Value: badVals,
-	}
+	m = MatcherStringList(badVals)
 
 	ok, err = m.match(input)
 	if err != nil {

--- a/pkg/rule/instrument.go
+++ b/pkg/rule/instrument.go
@@ -55,12 +55,12 @@ func (r *instrumentRuleRepo) UpdateWith(input Rule) (rl Rule, err error) {
 	return r.UpdateWith(input)
 }
 
-func (r *instrumentRuleRepo) ListAll(configID string) (rls []Rule, err error) {
+func (r *instrumentRuleRepo) ListAll() (rs []Rule, err error) {
 	defer func(begin time.Time) {
 		r.opObserve(r.store, labelRuleRepo, "ListAll", begin, err)
 	}(time.Now())
 
-	return r.ListAll(configID)
+	return r.ListAll()
 }
 
 func (r *instrumentRuleRepo) ListActive(

--- a/pkg/rule/logging.go
+++ b/pkg/rule/logging.go
@@ -54,7 +54,7 @@ func (r *logRuleRepo) Create(input Rule) (rl Rule, err error) {
 			logCreatedAt, input.createdAt,
 			logDuration, time.Since(begin).Nanoseconds(),
 			logEndTime, input.endTime,
-			logID, input.id,
+			logID, input.ID,
 			logKind, input.kind,
 			logName, input.name,
 			logOp, "Create",
@@ -109,7 +109,7 @@ func (r *logRuleRepo) UpdateWith(input Rule) (rl Rule, err error) {
 	return r.next.UpdateWith(input)
 }
 
-func (r *logRuleRepo) ListAll(configID string) (rls []Rule, err error) {
+func (r *logRuleRepo) ListAll() (rls []Rule, err error) {
 	defer func(begin time.Time) {
 		ps := []interface{}{
 			logDuration, time.Since(begin).Nanoseconds(),
@@ -124,7 +124,7 @@ func (r *logRuleRepo) ListAll(configID string) (rls []Rule, err error) {
 		_ = r.logger.Log(ps...)
 	}(time.Now())
 
-	return r.next.ListAll(configID)
+	return r.next.ListAll()
 }
 
 func (r *logRuleRepo) ListActive(configID string, now time.Time) (rls []Rule, err error) {

--- a/pkg/rule/postgres_test.go
+++ b/pkg/rule/postgres_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package rule
 
 import (
@@ -33,20 +35,20 @@ func TestPostgresRepoListAll(t *testing.T) {
 	testRepoListAll(t, preparePGRepo)
 }
 
-func TestPostgresRepoListActive(t *testing.T) {
-	testRepoListActive(t, preparePGRepo)
-}
-
-func TestPostgresRepoListActiveEmpty(t *testing.T) {
-	testRepoListActiveEmpty(t, preparePGRepo)
-}
-
 func TestPostgresRepoListAllEmpty(t *testing.T) {
 	testRepoListAllEmpty(t, preparePGRepo)
 }
 
 func TestPostgresRepoListDeleted(t *testing.T) {
 	testRepoListDeleted(t, preparePGRepo)
+}
+
+func TestPostgresRepoListActive(t *testing.T) {
+	testRepoListActive(t, preparePGRepo)
+}
+
+func TestPostgresRepoListActiveEmpty(t *testing.T) {
+	testRepoListActiveEmpty(t, preparePGRepo)
 }
 
 func preparePGRepo(t *testing.T) Repo {


### PR DESCRIPTION
Retrieve active rules and apply to the config rendering. This will make sure that overrides and rollouts will be applied and marks the most important integration in the system so far. Yet to be done are the other rule types.

* harden rule application on user configs
* expect prior decision on rule run
* handle non-matching rules
* integrate first part of rules in config rendering
* overhaul public visbility of types and methods
* consolidate parameters in rule pkg
* test user id matching in render