### PR TITLE
Add rollout attribute to rules

### DIFF
--- a/pkg/rule/inmem_test.go
+++ b/pkg/rule/inmem_test.go
@@ -34,8 +34,12 @@ func TestInmemRepoListAllEmpty(t *testing.T) {
 	testRepoListAllEmpty(t, prepareInmemRepo)
 }
 
-func TesstInmemRepoListDeleted(t *testing.T) {
+func TestInmemRepoListDeleted(t *testing.T) {
 	testRepoListDeleted(t, prepareInmemRepo)
+}
+
+func TestInmemRepoCreateRollout(t *testing.T) {
+	testRepoCreateRollout(t, prepareInmemRepo)
 }
 
 func prepareInmemRepo(t *testing.T) Repo {

--- a/pkg/rule/postgres_test.go
+++ b/pkg/rule/postgres_test.go
@@ -51,6 +51,10 @@ func TestPostgresRepoListActiveEmpty(t *testing.T) {
 	testRepoListActiveEmpty(t, preparePGRepo)
 }
 
+func TestPostgresRepoCreateRollout(t *testing.T) {
+	testRepoCreateRollout(t, preparePGRepo)
+}
+
 func preparePGRepo(t *testing.T) Repo {
 	db, err := sqlx.Connect("postgres", pgURI)
 	if err != nil {

--- a/pkg/rule/repo.go
+++ b/pkg/rule/repo.go
@@ -76,6 +76,7 @@ type Rule struct {
 	ID          string
 	kind        Kind
 	name        string
+	rollout     uint8
 	startTime   time.Time
 	updatedAt   time.Time
 }
@@ -92,7 +93,7 @@ func New(
 		active:      active,
 		buckets:     buckets,
 		configID:    configID,
-		createdAt:   time.Now(),
+		createdAt:   time.Now().UTC(),
 		criteria:    criteria,
 		description: description,
 		ID:          id,
@@ -131,6 +132,10 @@ func (r Rule) validate() error {
 
 	if r.name == "" {
 		return errors.Wrap(errors.ErrInvalidRule, "missing metadate.name")
+	}
+
+	if r.rollout > 100 {
+		return errors.Wrap(errors.ErrInvalidRule, "rollout percentage too high")
 	}
 
 	if len(r.buckets) > 1 {


### PR DESCRIPTION
In order to avoid migrating the database in the near future we added the rollout record used for storing the rollout percentage for each rule.