### PR TITLE
Implement CustomStringConvertible for Context object

### DIFF
--- a/sdk/ios/Configsum/Inputs/Context.swift
+++ b/sdk/ios/Configsum/Inputs/Context.swift
@@ -12,45 +12,45 @@ public enum Platform: String, Codable {
 }
 
 public struct User: Codable {
-    public let age: Int?
+    let age: Int?
     
     public init(age: Int? = nil) {
         self.age = age
     }
 }
 
-public struct OS: Codable {
-    public let platform: Platform
-    public let version: String
-}
-
-public struct Location: Codable {
-    public let locale: String
-    public let timezoneOffset: Int
-}
-
-public struct App: Codable {
-    public let version: String
-}
-
-public struct Device: Codable {
-    public let location: Location
-    public let os: OS
-}
-
 public class Context: Codable {
-    public let metadata: Metadata?
-    public let app: App
-    public let device: Device
-    public let user: User?
-    public let os: OS
-    public let location: Location
+    private let metadata: Metadata?
+    private let app: App
+    private let device: Device
+    private let user: User?
+    private let os: OS
+    private let location: Location
     
     enum CodingKeys: String, CodingKey {
         case app
         case device
         case metadata
         case user
+    }
+    
+    private struct OS: Codable {
+        let platform: Platform
+        let version: String
+    }
+    
+    private struct Location: Codable {
+        let locale: String
+        let timezoneOffset: Int
+    }
+    
+    private struct App: Codable {
+        let version: String
+    }
+    
+    private struct Device: Codable {
+        let location: Location
+        let os: OS
     }
     
     public init(appVersion: String,
@@ -87,5 +87,14 @@ public class Context: Codable {
         try container.encode(device, forKey: .device)
         try container.encodeIfPresent(metadata, forKey: .metadata)
         try container.encodeIfPresent(user, forKey: .user)
+    }
+}
+
+extension Context: CustomStringConvertible {
+    public var description: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let result = try! encoder.encode(self)
+        return String(data: result, encoding: .utf8)!
     }
 }

--- a/sdk/ios/ConfigsumTests/ConfigsumTests.swift
+++ b/sdk/ios/ConfigsumTests/ConfigsumTests.swift
@@ -55,9 +55,4 @@ class ConfigsumTests: XCTestCase {
                                                    defaultValue: false)
         XCTAssertFalse(boolValue)
     }
-    
-    func testGetRawConfig() {
-        let rawConfig = self.configsum.getRawConfig()
-        XCTAssertNotNil(rawConfig)
-    }
 }

--- a/sdk/ios/ConfigsumTests/ContextTests.swift
+++ b/sdk/ios/ConfigsumTests/ContextTests.swift
@@ -94,4 +94,18 @@ class ContextTests: XCTestCase {
         
         XCTAssertEqual(resultString, expectedString)
     }
+    
+    func testStringRepresentationOfContextObject() {
+        let context = Context(appVersion: "8.6.0",
+                              locale: Locale.current,
+                              platform: .iOS,
+                              osVersion: "11.0",
+                              metadata: ["name": "testName",
+                                         "age": 22,
+                                         "nestedDictionary": ["nestedStringList": ["item1", "item2"],
+                                                              "nestedBool": true]],
+                              user: User(age: 20))
+        let resultString = String(data: try! encoder.encode(context), encoding: .utf8)!
+        XCTAssertEqual(resultString, context.description)
+    }
 }

--- a/sdk/ios/ConfigsumTests/IntegrationTests.swift
+++ b/sdk/ios/ConfigsumTests/IntegrationTests.swift
@@ -128,7 +128,7 @@ class IntegrationTests: XCTestCase {
         waitForExpectations(timeout: 10.0, handler: nil)
     }
     
-    func testGetRawConfig() {
+    func testGetRawConfigNotNil() {
         let rawConfig = self.configsum.getRawConfig()
         XCTAssertNotNil(rawConfig)
     }

--- a/sdk/ios/ConfigsumTests/IntegrationTests.swift
+++ b/sdk/ios/ConfigsumTests/IntegrationTests.swift
@@ -127,6 +127,11 @@ class IntegrationTests: XCTestCase {
         }
         waitForExpectations(timeout: 10.0, handler: nil)
     }
+    
+    func testGetRawConfig() {
+        let rawConfig = self.configsum.getRawConfig()
+        XCTAssertNotNil(rawConfig)
+    }
 }
 
 


### PR DESCRIPTION
Implements the CustomStringConvertible protocol for Context in order to return a JSON string representation of the object. This is so that the Context can be passed as a string attribute if necessary.