### PR TITLE
Rules transport

### DIFF
--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -71,39 +71,19 @@ func (r baseListResponse) MarshalJSON() ([]byte, error) {
 	})
 }
 
-type responseParameter struct {
-	Name  string      `json:"name"`
-	Type  string      `json:"type"`
-	Value interface{} `json:"value"`
-}
-
-type responseParameters []responseParameter
-
-func (r responseParameters) Len() int {
-	return len(r)
-}
-
-func (r responseParameters) Less(i, j int) bool {
-	return r[i].Name > r[j].Name
-}
-
-func (r responseParameters) Swap(i, j int) {
-	r[i], r[j] = r[j], r[i]
-}
-
 type responseBaseConfig struct {
 	config BaseConfig
 }
 
 func (r responseBaseConfig) MarshalJSON() ([]byte, error) {
 	v := struct {
-		ClientID   string             `json:"client_id"`
-		Deleted    bool               `json:"deleted"`
-		ID         string             `json:"id"`
-		Name       string             `json:"name"`
-		Parameters responseParameters `json:"parameters"`
-		CreatedAt  time.Time          `json:"created_at"`
-		UpdatedAt  time.Time          `json:"updated_at"`
+		ClientID   string                  `json:"client_id"`
+		Deleted    bool                    `json:"deleted"`
+		ID         string                  `json:"id"`
+		Name       string                  `json:"name"`
+		Parameters rule.ResponseParameters `json:"parameters"`
+		CreatedAt  time.Time               `json:"created_at"`
+		UpdatedAt  time.Time               `json:"updated_at"`
 	}{
 		ClientID:  r.config.ClientID,
 		Deleted:   r.config.Deleted,
@@ -113,26 +93,13 @@ func (r responseBaseConfig) MarshalJSON() ([]byte, error) {
 		UpdatedAt: r.config.UpdatedAt,
 	}
 
-	ps := responseParameters{}
+	ps := rule.ResponseParameters{}
 
 	for k, val := range r.config.Parameters {
-		p := responseParameter{
+		ps = append(ps, rule.ResponseParameter{
 			Name:  k,
 			Value: val,
-		}
-
-		switch val.(type) {
-		case bool:
-			p.Type = "bool"
-		case float64:
-			p.Type = "number"
-		case string:
-			p.Type = "string"
-		default:
-			p.Type = "unknown"
-		}
-
-		ps = append(ps, p)
+		})
 	}
 
 	sort.Sort(ps)

--- a/pkg/config/transport_test.go
+++ b/pkg/config/transport_test.go
@@ -13,95 +13,11 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/oklog/ulid"
-	"github.com/xeipuuv/gojsonschema"
 	"golang.org/x/text/language"
 
-	"github.com/lifesum/configsum/pkg/errors"
 	"github.com/lifesum/configsum/pkg/generate"
 	"github.com/lifesum/configsum/pkg/rule"
 )
-
-const (
-	testSchema = `
-	{
-		  "$schema": "http://json-schema.org/draft-06/schema#",
-		  "title": "Client payload",
-		  "description": "Common set of information to determine device capabilities and user provided info.",
-		  "type": "object",
-		  "properties": {
-		  	"app": {
-		  		"type": "object",
-		  		"properties": {
-		  			"version": {
-		  				"description": "The version of the client application.",
-		  				"type": "string"
-		  			}
-		  		},
-		  		"required": ["version"]
-		  	}
-		  },
-		  "required": ["app"]
-	}`
-)
-
-func TestDecodeJSONSchemaValidInput(t *testing.T) {
-	var (
-		next = func(ctx context.Context, r *http.Request) (interface{}, error) {
-			return true, nil
-		}
-		payload = bytes.NewBufferString(`{"app": {"version": "6.4.1"}}`)
-		req     = httptest.NewRequest("PUT", "/v1/config/foo", payload)
-	)
-
-	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(testSchema))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	have, _ := decodeJSONSchema(next, schema)(context.Background(), req)
-	if want := true; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-}
-
-func TestDecodeJSONSchemaEmptyBody(t *testing.T) {
-	var (
-		next = func(ctx context.Context, r *http.Request) (interface{}, error) {
-			return nil, nil
-		}
-		req = httptest.NewRequest("PUT", "/v1/config/foo", nil)
-	)
-
-	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(testSchema))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, have := decodeJSONSchema(next, schema)(context.Background(), req)
-	if want := errors.ErrInvalidPayload; errors.Cause(have) != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-}
-
-func TestDecodeJSONSchemaMissingField(t *testing.T) {
-	var (
-		next = func(ctx context.Context, r *http.Request) (interface{}, error) {
-			return nil, nil
-		}
-		payload = bytes.NewBufferString(`{"platform": "WatchOS"}`)
-		req     = httptest.NewRequest("PUT", "/v1/config/foo", payload)
-	)
-
-	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(testSchema))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, have := decodeJSONSchema(next, schema)(context.Background(), req)
-	if want := errors.ErrInvalidPayload; errors.Cause(have) != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-}
 
 func TestDecodeBaseUpdateRequest(t *testing.T) {
 	var (
@@ -165,9 +81,9 @@ func TestExtractMuxVars(t *testing.T) {
 	var (
 		key = muxVar("testKey")
 		val = generate.RandomString(12)
+		req = httptest.NewRequest("GET", fmt.Sprintf("/root/%s", val), nil)
+		r   = mux.NewRouter()
 	)
-
-	r := mux.NewRouter()
 
 	r.Methods("GET").Path(`/root/{testKey}`).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := extractMuxVars(key)(context.Background(), r)
@@ -176,8 +92,6 @@ func TestExtractMuxVars(t *testing.T) {
 			t.Errorf("have %v, want %v", have, want)
 		}
 	})
-
-	req := httptest.NewRequest("GET", fmt.Sprintf("/root/%s", val), nil)
 
 	r.ServeHTTP(httptest.NewRecorder(), req)
 }

--- a/pkg/rule/endpoint.go
+++ b/pkg/rule/endpoint.go
@@ -27,6 +27,24 @@ func activateEndpoint(svc Service) endpoint.Endpoint {
 	}
 }
 
+type deactivateRequest struct {
+	id string
+}
+
+type deactivateResponse struct{}
+
+func (r deactivateResponse) StatusCode() int {
+	return http.StatusNoContent
+}
+
+func deactivateEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(deactivateRequest)
+
+		return activateResponse{}, svc.Deactivate(req.id)
+	}
+}
+
 type getRequest struct {
 	id string
 }

--- a/pkg/rule/endpoint.go
+++ b/pkg/rule/endpoint.go
@@ -41,7 +41,7 @@ func deactivateEndpoint(svc Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(deactivateRequest)
 
-		return activateResponse{}, svc.Deactivate(req.id)
+		return deactivateResponse{}, svc.Deactivate(req.id)
 	}
 }
 
@@ -251,4 +251,23 @@ func (r *responseRule) UnmarshalJSON(raw []byte) error {
 	}
 
 	return nil
+}
+
+type updateRolloutRequest struct {
+	id      string
+	rollout uint8
+}
+
+type updateRolloutResponse struct{}
+
+func (r updateRolloutResponse) StatusCode() int {
+	return http.StatusNoContent
+}
+
+func updateRolloutEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(updateRolloutRequest)
+
+		return updateRolloutResponse{}, svc.UpdateRollout(req.id, req.rollout)
+	}
 }

--- a/pkg/rule/endpoint.go
+++ b/pkg/rule/endpoint.go
@@ -163,6 +163,42 @@ func (r ResponseParameters) Swap(i, j int) {
 	r[i], r[j] = r[j], r[i]
 }
 
+type responseCriteria struct {
+	criteria *Criteria
+}
+
+func (r *responseCriteria) MarshalJSON() ([]byte, error) {
+	var u *responseCriteriaUser
+
+	if r.criteria.User != nil {
+		u = &responseCriteriaUser{user: r.criteria.User}
+	}
+
+	return json.Marshal(struct {
+		User *responseCriteriaUser `json:"user,omitempty"`
+	}{
+		User: u,
+	})
+}
+
+type responseCriteriaUser struct {
+	user *CriteriaUser
+}
+
+func (r *responseCriteriaUser) MarshalJSON() ([]byte, error) {
+	var is []string
+
+	if r.user.ID != nil {
+		is = []string(*r.user.ID)
+	}
+
+	return json.Marshal(struct {
+		ID []string `json:"id"`
+	}{
+		ID: is,
+	})
+}
+
 type responseRule struct {
 	rule Rule
 }
@@ -174,29 +210,35 @@ func (r *responseRule) MarshalJSON() ([]byte, error) {
 		bs = append(bs, responseBucket{bucket: b})
 	}
 
+	var c *responseCriteria
+
+	if r.rule.criteria != nil {
+		c = &responseCriteria{criteria: r.rule.criteria}
+	}
+
 	return json.Marshal(struct {
-		Active      bool             `json:"active"`
-		ActivatedAt time.Time        `json:"activated_at"`
-		Buckets     []responseBucket `json:"buckets"`
-		ConfigID    string           `json:"config_id"`
-		CreatedAt   string           `json:"created_at"`
-		Criteria    *Criteria        `json:"criteria,omitempty"`
-		Description string           `json:"description"`
-		Deleted     bool             `json:"deleted"`
-		EndTime     time.Time        `json:"end_time"`
-		ID          string           `json:"id"`
-		Kind        Kind             `json:"kind"`
-		Name        string           `json:"name"`
-		Rollout     uint8            `json:"rollout"`
-		StartTime   time.Time        `json:"start_time"`
-		UpdatedAt   time.Time        `json:"updated_at"`
+		Active      bool              `json:"active"`
+		ActivatedAt time.Time         `json:"activated_at"`
+		Buckets     []responseBucket  `json:"buckets"`
+		ConfigID    string            `json:"config_id"`
+		CreatedAt   string            `json:"created_at"`
+		Criteria    *responseCriteria `json:"criteria,omitempty"`
+		Description string            `json:"description"`
+		Deleted     bool              `json:"deleted"`
+		EndTime     time.Time         `json:"end_time"`
+		ID          string            `json:"id"`
+		Kind        Kind              `json:"kind"`
+		Name        string            `json:"name"`
+		Rollout     uint8             `json:"rollout"`
+		StartTime   time.Time         `json:"start_time"`
+		UpdatedAt   time.Time         `json:"updated_at"`
 	}{
 		Active:      r.rule.active,
 		ActivatedAt: r.rule.activatedAt,
 		Buckets:     bs,
 		ConfigID:    r.rule.configID,
 		CreatedAt:   r.rule.createdAt.Format(time.RFC3339Nano),
-		Criteria:    r.rule.criteria,
+		Criteria:    c,
 		Description: r.rule.description,
 		Deleted:     r.rule.deleted,
 		EndTime:     r.rule.endTime,

--- a/pkg/rule/endpoint.go
+++ b/pkg/rule/endpoint.go
@@ -1,0 +1,217 @@
+package rule
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+type getRequest struct {
+	id string
+}
+
+func getEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, rqeuest interface{}) (interface{}, error) {
+		req := rqeuest.(getRequest)
+
+		r, err := svc.GetByID(req.id)
+		if err != nil {
+			return nil, err
+		}
+
+		return &responseRule{rule: r}, nil
+	}
+}
+
+type responseBucket struct {
+	bucket Bucket
+}
+
+func (r *responseBucket) MarshalJSON() ([]byte, error) {
+	ps := []responseParameter{}
+
+	for k, v := range r.bucket.Parameters {
+		ps = append(ps, responseParameter{
+			key:   k,
+			value: v,
+		})
+	}
+
+	return json.Marshal(struct {
+		Name       string              `json:"name"`
+		Parameters []responseParameter `json:"parameters"`
+		Percentage int                 `json:"percentage"`
+	}{
+		Name:       r.bucket.Name,
+		Parameters: ps,
+		Percentage: r.bucket.Percentage,
+	})
+}
+
+func (r *responseBucket) UnmarshalJSON(raw []byte) error {
+	v := struct {
+		Name       string              `json:"name"`
+		Parameters []responseParameter `json:"parameters"`
+		Percentage int                 `json:"percentage"`
+	}{}
+
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return err
+	}
+
+	pm := Parameters{}
+
+	for _, p := range v.Parameters {
+		pm[p.key] = p.value
+	}
+
+	r.bucket = Bucket{
+		Name:       v.Name,
+		Parameters: pm,
+		Percentage: v.Percentage,
+	}
+
+	return nil
+}
+
+type responseParameter struct {
+	key   string
+	value interface{}
+}
+
+func (r responseParameter) MarshalJSON() ([]byte, error) {
+	v := struct {
+		Name  string      `json:"name"`
+		Type  string      `json:"type"`
+		Value interface{} `json:"value"`
+	}{
+		Name:  r.key,
+		Value: r.value,
+	}
+
+	switch r.value.(type) {
+	case bool:
+		v.Type = "bool"
+	case float64:
+		v.Type = "number"
+	case string:
+		v.Type = "string"
+	default:
+		v.Type = "unknown"
+	}
+
+	return json.Marshal(v)
+}
+
+func (r *responseParameter) UnmarshalJSON(raw []byte) error {
+	v := struct {
+		Name  string      `json:"name"`
+		Value interface{} `json:"value"`
+	}{}
+
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return err
+	}
+
+	r.key = v.Name
+	r.value = v.Value
+
+	return nil
+}
+
+type responseRule struct {
+	rule Rule
+}
+
+func (r *responseRule) MarshalJSON() ([]byte, error) {
+	bs := []responseBucket{}
+
+	for _, b := range r.rule.buckets {
+		bs = append(bs, responseBucket{bucket: b})
+	}
+
+	return json.Marshal(struct {
+		Active      bool             `json:"active"`
+		ActivatedAt time.Time        `json:"activated_at"`
+		Buckets     []responseBucket `json:"buckets"`
+		ConfigID    string           `json:"config_id"`
+		CreatedAt   string           `json:"created_at"`
+		Criteria    *Criteria        `json:"criteria,omitempty"`
+		Description string           `json:"description"`
+		Deleted     bool             `json:"deleted"`
+		EndTime     time.Time        `json:"end_time"`
+		ID          string           `json:"id"`
+		Kind        Kind             `json:"kind"`
+		Name        string           `json:"name"`
+		Rollout     uint8            `json:"rollout"`
+		StartTime   time.Time        `json:"start_time"`
+		UpdatedAt   time.Time        `json:"updated_at"`
+	}{
+		Active:      r.rule.active,
+		ActivatedAt: r.rule.activatedAt,
+		Buckets:     bs,
+		ConfigID:    r.rule.configID,
+		CreatedAt:   r.rule.createdAt.Format(time.RFC3339Nano),
+		Criteria:    r.rule.criteria,
+		Description: r.rule.description,
+		Deleted:     r.rule.deleted,
+		EndTime:     r.rule.endTime,
+		ID:          r.rule.ID,
+		Kind:        r.rule.kind,
+		Name:        r.rule.name,
+		Rollout:     r.rule.rollout,
+		StartTime:   r.rule.startTime,
+		UpdatedAt:   r.rule.updatedAt,
+	})
+}
+
+func (r *responseRule) UnmarshalJSON(raw []byte) error {
+	v := struct {
+		Active      bool             `json:"active"`
+		ActivatedAt time.Time        `json:"activated_at"`
+		Buckets     []responseBucket `json:"buckets"`
+		ConfigID    string           `json:"config_id"`
+		CreatedAt   string           `json:"created_at"`
+		Criteria    *Criteria        `json:"criteria,omitempty"`
+		Description string           `json:"description"`
+		Deleted     bool             `json:"deleted"`
+		EndTime     time.Time        `json:"end_time"`
+		ID          string           `json:"id"`
+		Kind        Kind             `json:"kind"`
+		Name        string           `json:"name"`
+		Rollout     uint8            `json:"rollout"`
+		StartTime   time.Time        `json:"start_time"`
+		UpdatedAt   time.Time        `json:"updated_at"`
+	}{}
+
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return err
+	}
+
+	bs := []Bucket{}
+
+	for _, rb := range v.Buckets {
+		bs = append(bs, rb.bucket)
+	}
+
+	r.rule = Rule{
+		active:      v.Active,
+		activatedAt: v.ActivatedAt,
+		buckets:     bs,
+		configID:    v.ConfigID,
+		criteria:    v.Criteria,
+		description: v.Description,
+		deleted:     v.Deleted,
+		endTime:     v.EndTime,
+		ID:          v.ID,
+		kind:        v.Kind,
+		name:        v.Name,
+		rollout:     v.Rollout,
+		startTime:   v.StartTime,
+		updatedAt:   v.UpdatedAt,
+	}
+
+	return nil
+}

--- a/pkg/rule/endpoint.go
+++ b/pkg/rule/endpoint.go
@@ -3,18 +3,37 @@ package rule
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"time"
 
 	"github.com/go-kit/kit/endpoint"
 )
+
+type activateRequest struct {
+	id string
+}
+
+type activateResponse struct{}
+
+func (r activateResponse) StatusCode() int {
+	return http.StatusNoContent
+}
+
+func activateEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(activateRequest)
+
+		return activateResponse{}, svc.Activate(req.id)
+	}
+}
 
 type getRequest struct {
 	id string
 }
 
 func getEndpoint(svc Service) endpoint.Endpoint {
-	return func(ctx context.Context, rqeuest interface{}) (interface{}, error) {
-		req := rqeuest.(getRequest)
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(getRequest)
 
 		r, err := svc.GetByID(req.id)
 		if err != nil {

--- a/pkg/rule/inmem.go
+++ b/pkg/rule/inmem.go
@@ -1,7 +1,6 @@
 package rule
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/lifesum/configsum/pkg/errors"
@@ -22,18 +21,16 @@ func NewInmemRuleRepo() Repo {
 	}
 }
 
-func (r *inmemRepo) GetByName(configID, name string) (Rule, error) {
-	rules, ok := r.rules[configID]
-	if !ok {
-		return Rule{}, errors.Wrap(errors.ErrNotFound, fmt.Sprintf("config id '%s'", configID))
+func (r *inmemRepo) GetByID(id string) (Rule, error) {
+	for _, cs := range r.rules {
+		for _, rule := range cs {
+			if rule.ID == id {
+				return rule, nil
+			}
+		}
 	}
 
-	rl, ok := rules[name]
-	if !ok {
-		return Rule{}, errors.Wrap(errors.ErrNotFound, fmt.Sprintf("rule name '%s'", name))
-	}
-
-	return rl, nil
+	return Rule{}, errors.Wrapf(errors.ErrNotFound, "rule id '%s'", id)
 }
 
 func (r *inmemRepo) Create(input Rule) (Rule, error) {

--- a/pkg/rule/inmem_test.go
+++ b/pkg/rule/inmem_test.go
@@ -2,8 +2,8 @@ package rule
 
 import "testing"
 
-func TestInmemRepoGetNotFound(t *testing.T) {
-	testRepoGetNotFound(t, prepareInmemRepo)
+func TestInmemRepoGetByIDNotFound(t *testing.T) {
+	testRepoGetByIDNotFound(t, prepareInmemRepo)
 }
 
 func TestInmemRepoCreateDuplicate(t *testing.T) {

--- a/pkg/rule/instrument.go
+++ b/pkg/rule/instrument.go
@@ -39,12 +39,12 @@ func (r *instrumentRuleRepo) Create(input Rule) (rl Rule, err error) {
 	return r.next.Create(input)
 }
 
-func (r *instrumentRuleRepo) GetByName(configID, name string) (rl Rule, err error) {
+func (r *instrumentRuleRepo) GetByID(id string) (rl Rule, err error) {
 	defer func(begin time.Time) {
-		r.opObserve(r.store, labelRuleRepo, "GetByName", begin, err)
+		r.opObserve(r.store, labelRuleRepo, "GetByID", begin, err)
 	}(time.Now())
 
-	return r.next.GetByName(configID, name)
+	return r.next.GetByID(id)
 }
 
 func (r *instrumentRuleRepo) UpdateWith(input Rule) (rl Rule, err error) {
@@ -52,7 +52,7 @@ func (r *instrumentRuleRepo) UpdateWith(input Rule) (rl Rule, err error) {
 		r.opObserve(r.store, labelRuleRepo, "UpdateWith", begin, err)
 	}(time.Now())
 
-	return r.UpdateWith(input)
+	return r.next.UpdateWith(input)
 }
 
 func (r *instrumentRuleRepo) ListAll() (rs []Rule, err error) {
@@ -60,7 +60,7 @@ func (r *instrumentRuleRepo) ListAll() (rs []Rule, err error) {
 		r.opObserve(r.store, labelRuleRepo, "ListAll", begin, err)
 	}(time.Now())
 
-	return r.ListAll()
+	return r.next.ListAll()
 }
 
 func (r *instrumentRuleRepo) ListActive(
@@ -79,7 +79,7 @@ func (r *instrumentRuleRepo) setup() (err error) {
 		r.opObserve(r.store, labelRuleRepo, "Setup", begin, err)
 	}(time.Now())
 
-	return r.setup()
+	return r.next.setup()
 }
 
 func (r *instrumentRuleRepo) teardown() (err error) {
@@ -87,5 +87,5 @@ func (r *instrumentRuleRepo) teardown() (err error) {
 		r.opObserve(r.store, labelRuleRepo, "Teardown", begin, err)
 	}(time.Now())
 
-	return r.teardown()
+	return r.next.teardown()
 }

--- a/pkg/rule/logging.go
+++ b/pkg/rule/logging.go
@@ -71,13 +71,12 @@ func (r *logRuleRepo) Create(input Rule) (rl Rule, err error) {
 	return r.next.Create(input)
 }
 
-func (r *logRuleRepo) GetByName(configID, name string) (rl Rule, err error) {
+func (r *logRuleRepo) GetByID(id string) (rl Rule, err error) {
 	defer func(begin time.Time) {
 		ps := []interface{}{
 			logDuration, time.Since(begin).Nanoseconds(),
-			logConfigID, configID,
-			logName, name,
-			logOp, "GetByName",
+			logID, id,
+			logOp, "GetByID",
 		}
 
 		if err != nil {
@@ -87,7 +86,7 @@ func (r *logRuleRepo) GetByName(configID, name string) (rl Rule, err error) {
 		_ = r.logger.Log(ps...)
 	}(time.Now())
 
-	return r.next.GetByName(configID, name)
+	return r.next.GetByID(id)
 }
 
 func (r *logRuleRepo) UpdateWith(input Rule) (rl Rule, err error) {

--- a/pkg/rule/postgres_test.go
+++ b/pkg/rule/postgres_test.go
@@ -15,8 +15,8 @@ import (
 
 var pgURI string
 
-func TestPostgresRepoGetNotFound(t *testing.T) {
-	testRepoGetNotFound(t, preparePGRepo)
+func TestPostgresRepoGetByIDNotFound(t *testing.T) {
+	testRepoGetByIDNotFound(t, preparePGRepo)
 }
 
 func TestPostgresRepoCreateDuplicate(t *testing.T) {

--- a/pkg/rule/repo.go
+++ b/pkg/rule/repo.go
@@ -48,7 +48,7 @@ type Repo interface {
 	lifecycle
 
 	Create(input Rule) (Rule, error)
-	GetByName(configID, name string) (Rule, error)
+	GetByID(string) (Rule, error)
 	UpdateWith(input Rule) (Rule, error)
 	ListAll() ([]Rule, error)
 	ListActive(configID string, now time.Time) ([]Rule, error)

--- a/pkg/rule/repo.go
+++ b/pkg/rule/repo.go
@@ -43,6 +43,9 @@ type ContextUser struct {
 // results of dice rolls for percenatage based decisions.
 type Decisions map[string][]int
 
+// List is a collection of Rule.
+type List []Rule
+
 // Repo provides access to rules.
 type Repo interface {
 	lifecycle

--- a/pkg/rule/repo_test.go
+++ b/pkg/rule/repo_test.go
@@ -121,7 +121,7 @@ func testRepoGet(t *testing.T, p prepareFunc) {
 		t.Fatal(err)
 	}
 
-	r, err := repo.GetByName(rule.configID, rule.name)
+	r, err := repo.GetByID(rule.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,14 +155,8 @@ func testRepoGet(t *testing.T, p prepareFunc) {
 	}
 }
 
-func testRepoGetNotFound(t *testing.T, p prepareFunc) {
-	var (
-		configID = generate.RandomString(24)
-		name     = generate.RandomString(24)
-		repo     = p(t)
-	)
-
-	_, err := repo.GetByName(configID, name)
+func testRepoGetByIDNotFound(t *testing.T, p prepareFunc) {
+	_, err := p(t).GetByID(generate.RandomString(12))
 	if have, want := errors.Cause(err), errors.ErrNotFound; have != want {
 		t.Errorf("have %v, want %v", have, want)
 	}
@@ -432,7 +426,7 @@ func testRepoUpdateWith(t *testing.T, p prepareFunc) {
 		t.Fatal(err)
 	}
 
-	rl, err := repo.GetByName(updatedRule.configID, updatedRule.name)
+	rl, err := repo.GetByID(updatedRule.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -719,7 +713,7 @@ func testRepoCreateRollout(t *testing.T, p prepareFunc) {
 		t.Fatal(err)
 	}
 
-	retrieved, err := repo.GetByName(configID, name)
+	retrieved, err := repo.GetByID(rule.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/rule/service.go
+++ b/pkg/rule/service.go
@@ -5,6 +5,7 @@ type Service interface {
 	Activate(id string) error
 	Deactivate(id string) error
 	GetByID(id string) (Rule, error)
+	List() (List, error)
 	UpdateRollout(id string, rollout uint8) error
 }
 
@@ -55,6 +56,10 @@ func (s *service) Deactivate(id string) error {
 
 func (s *service) GetByID(id string) (Rule, error) {
 	return s.repo.GetByID(id)
+}
+
+func (s *service) List() (List, error) {
+	return s.repo.ListAll()
 }
 
 func (s *service) UpdateRollout(id string, rollout uint8) error {

--- a/pkg/rule/service.go
+++ b/pkg/rule/service.go
@@ -1,0 +1,21 @@
+package rule
+
+// Service for Rule interactions.
+type Service interface {
+	GetByID(string) (Rule, error)
+}
+
+type service struct {
+	repo Repo
+}
+
+// NewService for Rule interactions.
+func NewService(repo Repo) Service {
+	return &service{
+		repo: repo,
+	}
+}
+
+func (s *service) GetByID(id string) (Rule, error) {
+	return s.repo.GetByID(id)
+}

--- a/pkg/rule/service.go
+++ b/pkg/rule/service.go
@@ -3,6 +3,7 @@ package rule
 // Service for Rule interactions.
 type Service interface {
 	Activate(id string) error
+	Deactivate(id string) error
 	GetByID(id string) (Rule, error)
 }
 
@@ -28,6 +29,23 @@ func (s *service) Activate(id string) error {
 	}
 
 	r.active = true
+
+	_, err = s.repo.UpdateWith(r)
+
+	return err
+}
+
+func (s *service) Deactivate(id string) error {
+	r, err := s.repo.GetByID(id)
+	if err != nil {
+		return err
+	}
+
+	if !r.active {
+		return nil
+	}
+
+	r.active = false
 
 	_, err = s.repo.UpdateWith(r)
 

--- a/pkg/rule/service.go
+++ b/pkg/rule/service.go
@@ -5,6 +5,7 @@ type Service interface {
 	Activate(id string) error
 	Deactivate(id string) error
 	GetByID(id string) (Rule, error)
+	UpdateRollout(id string, rollout uint8) error
 }
 
 type service struct {
@@ -54,4 +55,21 @@ func (s *service) Deactivate(id string) error {
 
 func (s *service) GetByID(id string) (Rule, error) {
 	return s.repo.GetByID(id)
+}
+
+func (s *service) UpdateRollout(id string, rollout uint8) error {
+	r, err := s.repo.GetByID(id)
+	if err != nil {
+		return err
+	}
+
+	if r.rollout == rollout {
+		return nil
+	}
+
+	r.rollout = rollout
+
+	_, err = s.repo.UpdateWith(r)
+
+	return err
 }

--- a/pkg/rule/service.go
+++ b/pkg/rule/service.go
@@ -2,7 +2,8 @@ package rule
 
 // Service for Rule interactions.
 type Service interface {
-	GetByID(string) (Rule, error)
+	Activate(id string) error
+	GetByID(id string) (Rule, error)
 }
 
 type service struct {
@@ -14,6 +15,23 @@ func NewService(repo Repo) Service {
 	return &service{
 		repo: repo,
 	}
+}
+
+func (s *service) Activate(id string) error {
+	r, err := s.repo.GetByID(id)
+	if err != nil {
+		return err
+	}
+
+	if r.active {
+		return nil
+	}
+
+	r.active = true
+
+	_, err = s.repo.UpdateWith(r)
+
+	return err
 }
 
 func (s *service) GetByID(id string) (Rule, error) {

--- a/pkg/rule/transport.go
+++ b/pkg/rule/transport.go
@@ -1,0 +1,58 @@
+package rule
+
+import (
+	"context"
+	"net/http"
+
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+
+	"github.com/lifesum/configsum/pkg/errors"
+)
+
+// URL fragments.
+const (
+	varID muxVar = "id"
+)
+
+type muxVar string
+
+func MakeHandler(svc Service, opts ...kithttp.ServerOption) http.Handler {
+	r := mux.NewRouter()
+	r.StrictSlash(true)
+
+	r.Methods("GET").Path(`/{id:[a-zA-Z0-9]+}`).Name("ruleGet").Handler(
+		kithttp.NewServer(
+			getEndpoint(svc),
+			decodeGetRequest,
+			kithttp.EncodeJSONResponse,
+			append(
+				opts,
+				kithttp.ServerBefore(extractMuxVars(varID)),
+			)...,
+		),
+	)
+
+	return r
+}
+
+func decodeGetRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	id, ok := ctx.Value(varID).(string)
+	if !ok {
+		return nil, errors.Wrap(errors.ErrVarMissing, "id")
+	}
+
+	return getRequest{id: id}, nil
+}
+
+func extractMuxVars(keys ...muxVar) kithttp.RequestFunc {
+	return func(ctx context.Context, r *http.Request) context.Context {
+		for _, k := range keys {
+			if v, ok := mux.Vars(r)[string(k)]; ok {
+				ctx = context.WithValue(ctx, k, v)
+			}
+		}
+
+		return ctx
+	}
+}

--- a/pkg/rule/transport.go
+++ b/pkg/rule/transport.go
@@ -45,6 +45,18 @@ func MakeHandler(svc Service, opts ...kithttp.ServerOption) http.Handler {
 		),
 	)
 
+	r.Methods("PUT").Path(`/{id:[a-zA-Z0-9]+}/deactivate`).Name("ruleDeactivate").Handler(
+		kithttp.NewServer(
+			deactivateEndpoint(svc),
+			decodeDeactivateRequest,
+			kithttp.EncodeJSONResponse,
+			append(
+				opts,
+				kithttp.ServerBefore(extractMuxVars(varID)),
+			)...,
+		),
+	)
+
 	return r
 }
 
@@ -55,6 +67,15 @@ func decodeActivateRequest(ctx context.Context, r *http.Request) (interface{}, e
 	}
 
 	return activateRequest{id: id}, nil
+}
+
+func decodeDeactivateRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	id, ok := ctx.Value(varID).(string)
+	if !ok {
+		return nil, errors.Wrap(errors.ErrVarMissing, "id")
+	}
+
+	return deactivateRequest{id: id}, nil
 }
 
 func decodeGetRequest(ctx context.Context, r *http.Request) (interface{}, error) {

--- a/pkg/rule/transport.go
+++ b/pkg/rule/transport.go
@@ -33,7 +33,28 @@ func MakeHandler(svc Service, opts ...kithttp.ServerOption) http.Handler {
 		),
 	)
 
+	r.Methods("PUT").Path(`/{id:[a-zA-Z0-9]+}/activate`).Name("ruleActivate").Handler(
+		kithttp.NewServer(
+			activateEndpoint(svc),
+			decodeActivateRequest,
+			kithttp.EncodeJSONResponse,
+			append(
+				opts,
+				kithttp.ServerBefore(extractMuxVars(varID)),
+			)...,
+		),
+	)
+
 	return r
+}
+
+func decodeActivateRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	id, ok := ctx.Value(varID).(string)
+	if !ok {
+		return nil, errors.Wrap(errors.ErrVarMissing, "id")
+	}
+
+	return activateRequest{id: id}, nil
 }
 
 func decodeGetRequest(ctx context.Context, r *http.Request) (interface{}, error) {

--- a/pkg/rule/transport.go
+++ b/pkg/rule/transport.go
@@ -22,6 +22,15 @@ func MakeHandler(svc Service, opts ...kithttp.ServerOption) http.Handler {
 	r := mux.NewRouter()
 	r.StrictSlash(true)
 
+	r.Methods("GET").Path(`/`).Name("ruleList").Handler(
+		kithttp.NewServer(
+			listEndpoint(svc),
+			decodeListRequest,
+			kithttp.EncodeJSONResponse,
+			opts...,
+		),
+	)
+
 	r.Methods("GET").Path(`/{id:[a-zA-Z0-9]+}`).Name("ruleGet").Handler(
 		kithttp.NewServer(
 			getEndpoint(svc),
@@ -98,6 +107,10 @@ func decodeGetRequest(ctx context.Context, r *http.Request) (interface{}, error)
 	}
 
 	return getRequest{id: id}, nil
+}
+
+func decodeListRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	return struct{}{}, nil
 }
 
 func decodeUpdateRolloutRequest(ctx context.Context, r *http.Request) (interface{}, error) {

--- a/pkg/rule/transport_test.go
+++ b/pkg/rule/transport_test.go
@@ -1,0 +1,158 @@
+package rule
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/oklog/ulid"
+
+	"github.com/lifesum/configsum/pkg/generate"
+)
+
+func TestRuleGet(t *testing.T) {
+	var (
+		configID = generate.RandomString(12)
+		repo     = preparePGRepo(t)
+		svc      = NewService(repo)
+		id, _    = ulid.New(ulid.Timestamp(time.Now()), seed)
+		target   = fmt.Sprintf("/%s", id.String())
+		req      = httptest.NewRequest("GET", target, nil)
+		rec      = httptest.NewRecorder()
+		r        = MakeHandler(svc)
+	)
+
+	rule, err := New(
+		id.String(),
+		configID,
+		"override_funky_staff",
+		"Overrides funky feature for all staff memebers",
+		KindOverride,
+		true,
+		nil,
+		[]Bucket{
+			{
+				Name: "default",
+				Parameters: Parameters{
+					"feature_funky_toggle": true,
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := repo.Create(rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r.ServeHTTP(rec, req)
+
+	resp := responseRule{}
+
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := resp.rule.active, created.active; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.activatedAt, created.activatedAt; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.buckets, created.buckets; !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.configID, created.configID; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.criteria, created.criteria; !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.description, created.description; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.deleted, created.deleted; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.endTime, created.endTime; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.ID, created.ID; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.kind, created.kind; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.name, created.name; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.rollout, created.rollout; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	if have, want := resp.rule.startTime, created.startTime; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func TestDecodeGetRequest(t *testing.T) {
+	var (
+		seed   = rand.New(rand.NewSource(time.Now().UnixNano()))
+		id, _  = ulid.New(ulid.Timestamp(time.Now()), seed)
+		ctx    = context.WithValue(context.Background(), varID, id.String())
+		target = fmt.Sprintf("/%s", id.String())
+		r      = httptest.NewRequest("GET", target, nil)
+	)
+
+	raw, err := decodeGetRequest(ctx, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := getRequest{id: id.String()}
+
+	if have := raw.(getRequest); !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func TestExtractMuxVars(t *testing.T) {
+	var (
+		key = muxVar("testKey")
+		val = generate.RandomString(12)
+		req = httptest.NewRequest("GET", fmt.Sprintf("/root/%s", val), nil)
+		r   = mux.NewRouter()
+	)
+
+	r.Methods("GET").Path(`/root/{testKey}`).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := extractMuxVars(key)(context.Background(), r)
+
+		if have, want := ctx.Value(key), val; have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+	})
+
+	r.ServeHTTP(httptest.NewRecorder(), req)
+}

--- a/pkg/rule/transport_test.go
+++ b/pkg/rule/transport_test.go
@@ -1,6 +1,7 @@
 package rule
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -93,8 +94,8 @@ func TestRuleDeactivate(t *testing.T) {
 	rule, err := New(
 		id.String(),
 		configID,
-		"override_funky_staff",
-		"Overrides funky feature for all staff memebers",
+		generate.RandomString(12),
+		generate.RandomString(42),
 		KindOverride,
 		true,
 		nil,
@@ -128,6 +129,68 @@ func TestRuleDeactivate(t *testing.T) {
 	}
 
 	if have, want := updated.active, false; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	// Check for idempotency.
+	r.ServeHTTP(rec, req)
+
+	if have, want := rec.Code, http.StatusNoContent; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func TestRuleUpdateRollout(t *testing.T) {
+	var (
+		configID = generate.RandomString(12)
+		repo     = preparePGRepo(t)
+		svc      = NewService(repo)
+		id, _    = ulid.New(ulid.Timestamp(time.Now()), seed)
+		payload  = bytes.NewBufferString(`{"rollout": 13}`)
+		target   = fmt.Sprintf("/%s/rollout", id.String())
+		req      = httptest.NewRequest("PUT", target, payload)
+		rec      = httptest.NewRecorder()
+		r        = MakeHandler(svc)
+	)
+
+	rule, err := New(
+		id.String(),
+		configID,
+		generate.RandomString(12),
+		generate.RandomString(42),
+		KindOverride,
+		true,
+		nil,
+		[]Bucket{
+			{
+				Name: "default",
+				Parameters: Parameters{
+					"feature_funky_toggle": true,
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Create(rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r.ServeHTTP(rec, req)
+
+	if have, want := rec.Code, http.StatusNoContent; have != want {
+		t.Fatalf("have %v, want %v", have, want)
+	}
+
+	updated, err := repo.GetByID(id.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := updated.rollout, uint8(13); have != want {
 		t.Errorf("have %v, want %v", have, want)
 	}
 

--- a/pkg/rule/transport_test.go
+++ b/pkg/rule/transport_test.go
@@ -17,6 +17,67 @@ import (
 	"github.com/lifesum/configsum/pkg/generate"
 )
 
+func TestRuleActivate(t *testing.T) {
+	var (
+		configID = generate.RandomString(12)
+		repo     = preparePGRepo(t)
+		svc      = NewService(repo)
+		id, _    = ulid.New(ulid.Timestamp(time.Now()), seed)
+		target   = fmt.Sprintf("/%s/activate", id.String())
+		req      = httptest.NewRequest("PUT", target, nil)
+		rec      = httptest.NewRecorder()
+		r        = MakeHandler(svc)
+	)
+
+	rule, err := New(
+		id.String(),
+		configID,
+		"override_funky_staff",
+		"Overrides funky feature for all staff memebers",
+		KindOverride,
+		false,
+		nil,
+		[]Bucket{
+			{
+				Name: "default",
+				Parameters: Parameters{
+					"feature_funky_toggle": true,
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Create(rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r.ServeHTTP(rec, req)
+
+	if have, want := rec.Code, http.StatusNoContent; have != want {
+		t.Fatalf("have %v, want %v", have, want)
+	}
+
+	updated, err := repo.GetByID(id.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := updated.active, true; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	// Check for idempotency.
+	r.ServeHTTP(rec, req)
+
+	if have, want := rec.Code, http.StatusNoContent; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
 func TestRuleGet(t *testing.T) {
 	var (
 		configID = generate.RandomString(12)

--- a/pkg/transport/http/transport_test.go
+++ b/pkg/transport/http/transport_test.go
@@ -1,0 +1,95 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/lifesum/configsum/pkg/errors"
+)
+
+const (
+	testSchema = `
+	{
+		  "$schema": "http://json-schema.org/draft-06/schema#",
+		  "title": "Client payload",
+		  "description": "Common set of information to determine device capabilities and user provided info.",
+		  "type": "object",
+		  "properties": {
+		  	"app": {
+		  		"type": "object",
+		  		"properties": {
+		  			"version": {
+		  				"description": "The version of the client application.",
+		  				"type": "string"
+		  			}
+		  		},
+		  		"required": ["version"]
+		  	}
+		  },
+		  "required": ["app"]
+	}`
+)
+
+func TestDecodeJSONSchemaValidInput(t *testing.T) {
+	var (
+		next = func(ctx context.Context, r *http.Request) (interface{}, error) {
+			return true, nil
+		}
+		payload = bytes.NewBufferString(`{"app": {"version": "6.4.1"}}`)
+		req     = httptest.NewRequest("PUT", "/v1/config/foo", payload)
+	)
+
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(testSchema))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	have, _ := DecodeJSONSchema(next, schema)(context.Background(), req)
+	if want := true; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func TestDecodeJSONSchemaEmptyBody(t *testing.T) {
+	var (
+		next = func(ctx context.Context, r *http.Request) (interface{}, error) {
+			return nil, nil
+		}
+		req = httptest.NewRequest("PUT", "/v1/config/foo", nil)
+	)
+
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(testSchema))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, have := DecodeJSONSchema(next, schema)(context.Background(), req)
+	if want := errors.ErrInvalidPayload; errors.Cause(have) != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func TestDecodeJSONSchemaMissingField(t *testing.T) {
+	var (
+		next = func(ctx context.Context, r *http.Request) (interface{}, error) {
+			return nil, nil
+		}
+		payload = bytes.NewBufferString(`{"platform": "WatchOS"}`)
+		req     = httptest.NewRequest("PUT", "/v1/config/foo", payload)
+	)
+
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(testSchema))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, have := DecodeJSONSchema(next, schema)(context.Background(), req)
+	if want := errors.ErrInvalidPayload; errors.Cause(have) != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}


### PR DESCRIPTION
This change introduces transport for rules in order to enable manipulation from the Console UI. We follow along the structure of the rest of the system, informed by go-kit. Also testing high-level tests on the transport level by running requests against the mounted endpoints against Postgres to get a better sense of the end-to-end functionality.

* move json schema encoding 
* set up rule transport structure
* set up rule service
* implement get endpoint
* implement rule activation endpoint
* implement rule deactivation endpoint
* implement rule update rollout endpoint
* implement rule list endpoint
* consolidate parameter response types