### PR TITLE
Locale criteria

### DIFF
--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -171,6 +171,24 @@ type userInfo struct {
 	Subscription int
 }
 
+func (u *userInfo) UnmarshalJSON(raw []byte) error {
+	v := struct {
+		Age          uint8  `json:"age"`
+		Registered   string `json:"registered"`
+		Subscription int    `json:"subscription"`
+	}{}
+
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return err
+	}
+
+	u.Age = v.Age
+	u.Registered = v.Registered
+	u.Subscription = v.Subscription
+
+	return nil
+}
+
 type userRenderContext struct {
 	Device device   `json:"device"`
 	User   userInfo `json:"user"`

--- a/pkg/config/endpoint.go
+++ b/pkg/config/endpoint.go
@@ -167,15 +167,15 @@ func (l *location) UnmarshalJSON(raw []byte) error {
 
 type userInfo struct {
 	Age          uint8
-	Registered   string
+	Registered   time.Time
 	Subscription int
 }
 
 func (u *userInfo) UnmarshalJSON(raw []byte) error {
 	v := struct {
-		Age          uint8  `json:"age"`
-		Registered   string `json:"registered"`
-		Subscription int    `json:"subscription"`
+		Age          uint8     `json:"age"`
+		Registered   time.Time `json:"registered"`
+		Subscription int       `json:"subscription"`
 	}{}
 
 	if err := json.Unmarshal(raw, &v); err != nil {

--- a/pkg/config/endpoint_test.go
+++ b/pkg/config/endpoint_test.go
@@ -17,3 +17,19 @@ func TestLocationInvalidLocale(t *testing.T) {
 		t.Errorf("have %v, want %v", have, want)
 	}
 }
+
+func TestUnmarshalUserContext(t *testing.T) {
+	var (
+		input = []byte(`{
+			"age": 27,
+			"registered": "2017-12-04T23:11:38Z",
+			"subscription": 2
+			}`)
+		u = userInfo{}
+	)
+
+	err := u.UnmarshalJSON(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/config/endpoint_test.go
+++ b/pkg/config/endpoint_test.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	"github.com/lifesum/configsum/pkg/errors"
-
+	"reflect"
 	"testing"
+
+	"github.com/lifesum/configsum/pkg/errors"
 )
 
 func TestLocationInvalidLocale(t *testing.T) {
@@ -31,5 +32,16 @@ func TestUnmarshalUserContext(t *testing.T) {
 	err := u.UnmarshalJSON(input)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	have := u
+	want := userInfo{
+		Age:          27,
+		Registered:   "2017-12-04T23:11:38Z",
+		Subscription: 2,
+	}
+
+	if !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
 	}
 }

--- a/pkg/config/endpoint_test.go
+++ b/pkg/config/endpoint_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/lifesum/configsum/pkg/errors"
 )
@@ -29,7 +30,12 @@ func TestUnmarshalUserContext(t *testing.T) {
 		u = userInfo{}
 	)
 
-	err := u.UnmarshalJSON(input)
+	timestamp, err := time.Parse(time.RFC3339, "2017-12-04T23:11:38Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = u.UnmarshalJSON(input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +43,7 @@ func TestUnmarshalUserContext(t *testing.T) {
 	have := u
 	want := userInfo{
 		Age:          27,
-		Registered:   "2017-12-04T23:11:38Z",
+		Registered:   timestamp,
 		Subscription: 2,
 	}
 

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -143,6 +143,9 @@ func (s *userService) Render(
 				Registered:   ctx.User.Registered,
 				Subscription: ctx.User.Subscription,
 			},
+			Locale: rule.ContextLocale{
+				Locale: ctx.Device.Location.locale,
+			},
 		}
 
 		pm, d, err := r.Run(params, ctx, uc.ruleDecisions[r.ID], r.RandFunc)

--- a/pkg/rule/criteria.go
+++ b/pkg/rule/criteria.go
@@ -22,7 +22,8 @@ type comparator int8
 
 // Criteria defines if a rule will match on the given context data.
 type Criteria struct {
-	User *CriteriaUser
+	User   *CriteriaUser
+	Locale *CriteriaLocale
 }
 
 // CriteriaUser holds all relevant matchers concerning a user.
@@ -30,6 +31,11 @@ type CriteriaUser struct {
 	Age          *MatcherInt
 	ID           *MatcherStringList
 	Subscription *MatcherInt
+}
+
+// CriteriaLocale hold all relevant matchers concerning the locale.
+type CriteriaLocale struct {
+	Locale *MatcherString
 }
 
 // MatcherBool defines methods for matching a rule on bool type
@@ -66,9 +72,22 @@ func (m MatcherInt) match(input interface{}) (bool, error) {
 	}
 }
 
-type matcherString struct {
-	comparator comparator
-	value      string
+// MatcherString defines methods for matching a rule on string type
+type MatcherString struct {
+	value string
+}
+
+func (m MatcherString) match(input interface{}) (bool, error) {
+	t, ok := input.(string)
+	if !ok {
+		return false, errors.Wrapf(errors.ErrInvalidTypeToMatch, "missmatch %s != string", reflect.TypeOf(input).Kind())
+	}
+
+	if t == m.value {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 type matcherListInt struct {

--- a/pkg/rule/criteria_test.go
+++ b/pkg/rule/criteria_test.go
@@ -43,3 +43,37 @@ func TestMatcherListString(t *testing.T) {
 		t.Errorf("expect input not to match")
 	}
 }
+
+func TestMatcherString(t *testing.T) {
+	var (
+		input   = generate.RandomString(24)
+		goodVal = input
+		badVal  = generate.RandomString(24)
+	)
+
+	m := MatcherString{
+		value: goodVal,
+	}
+
+	ok, err := m.match(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !ok {
+		t.Error("expect input to match")
+	}
+
+	m = MatcherString{
+		value: badVal,
+	}
+
+	ok, err = m.match(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ok {
+		t.Error("expect input not to match")
+	}
+}

--- a/pkg/rule/repo.go
+++ b/pkg/rule/repo.go
@@ -41,7 +41,7 @@ type Context struct {
 type ContextUser struct {
 	Age          uint8
 	ID           string
-	Registered   string
+	Registered   time.Time
 	Subscription int
 }
 

--- a/pkg/rule/repo.go
+++ b/pkg/rule/repo.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"time"
 
+	"golang.org/x/text/language"
+
 	"github.com/lifesum/configsum/pkg/errors"
 	"github.com/lifesum/configsum/pkg/generate"
 )
@@ -31,7 +33,8 @@ type Bucket struct {
 
 // Context carries information for rule decisions to match criteria.
 type Context struct {
-	User ContextUser
+	User   ContextUser
+	Locale ContextLocale
 }
 
 // ContextUser bundles user information for rule criteria to match.
@@ -40,6 +43,11 @@ type ContextUser struct {
 	ID           string
 	Registered   string
 	Subscription int
+}
+
+// ContextLocale bundles locale information for rule criteria to match.
+type ContextLocale struct {
+	Locale language.Tag
 }
 
 // Decisions reflects a matrix of rules applied to a config and if present the


### PR DESCRIPTION
This effort extends the criteria for matching rules with the locale attribute adding another dimension for filtering users.

* match method for string type
* lift locale from endpoint to service
* unmarshal User object form context
* tests for unmarshal, string matching and rule matching