### PR TITLE
Restructure of rule criteria

### DIFF
--- a/cmd/configsum/config.go
+++ b/cmd/configsum/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/lifesum/configsum/pkg/auth/simple"
 	"github.com/lifesum/configsum/pkg/client"
 	"github.com/lifesum/configsum/pkg/config"
+	"github.com/lifesum/configsum/pkg/generate"
 	"github.com/lifesum/configsum/pkg/instrument"
 	"github.com/lifesum/configsum/pkg/rule"
 	confhttp "github.com/lifesum/configsum/pkg/transport/http"
@@ -110,10 +112,11 @@ func runConfig(args []string, logger log.Logger) error {
 
 	// Setup service.
 	var (
+		seed         = rand.New(rand.NewSource(time.Now().UnixNano()))
 		mux          = http.NewServeMux()
 		prefixConfig = fmt.Sprintf(`/%s/config`, apiVersion)
 		clientSVC    = client.NewService(clientRepo, tokenRepo)
-		svc          = config.NewUserService(baseRepo, userRepo, ruleRepo)
+		svc          = config.NewUserService(baseRepo, userRepo, ruleRepo, generate.RandPercentage(seed))
 		opts         = []kithttp.ServerOption{
 			kithttp.ServerBefore(kithttp.PopulateRequestContext),
 			kithttp.ServerBefore(confhttp.PopulateRequestContext),

--- a/pkg/config/transport_test.go
+++ b/pkg/config/transport_test.go
@@ -11,10 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 	"github.com/oklog/ulid"
 	"golang.org/x/text/language"
 
+	"github.com/lifesum/configsum/pkg/auth"
+	"github.com/lifesum/configsum/pkg/client"
 	"github.com/lifesum/configsum/pkg/generate"
 	"github.com/lifesum/configsum/pkg/rule"
 )
@@ -94,4 +97,112 @@ func TestExtractMuxVars(t *testing.T) {
 	})
 
 	r.ServeHTTP(httptest.NewRecorder(), req)
+}
+
+func TestUserRender(t *testing.T) {
+	var (
+		baseID     = generate.RandomString(16)
+		baseName   = "some-base-config-4473"
+		baseRepo   = preparePGBaseRepo(t)
+		clientID   = generate.RandomString(12)
+		userID     = generate.RandomString(12)
+		us         = language.MustParseRegion("US")
+		en         = language.MustParseBase("en")
+		paramKey   = generate.RandomString(6)
+		payload    = bytes.NewBufferString(`{"app": { "version": "8.6.7" }, "device": {"location": {"locale": "en_US", "timezoneOffset": 3600}, "os": { "platform": "iOS", "version": "8.0"}}, "user": { "subscription": 1 } }`)
+		target     = fmt.Sprintf("/%s", baseName)
+		parameters = rule.Parameters{
+			paramKey: false,
+		}
+		req       = httptest.NewRequest("PUT", target, payload)
+		rec       = httptest.NewRecorder()
+		ruleRepo  = prepareRuleRepo(t)
+		userRepo  = preparePGUserRepo(t)
+		seed      = rand.New(rand.NewSource(time.Now().UnixNano()))
+		svc       = NewUserService(baseRepo, userRepo, ruleRepo, generate.RandPercentage(seed))
+		ruleID, _ = ulid.New(ulid.Timestamp(time.Now()), seed)
+		router    = MakeHandler(svc, injectAuth(clientID, userID))
+	)
+
+	_, err := baseRepo.Create(baseID, clientID, baseName, parameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	enUS, err := language.Compose(en, us)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	override, err := rule.New(
+		ruleID.String(),
+		baseID,
+		generate.RandomString(12),
+		generate.RandomString(12),
+		rule.KindOverride,
+		true,
+		rule.Criteria{
+			rule.Criterion{
+				Comparator: rule.ComparatorEQ,
+				Key:        rule.DeviceLocationLocale,
+				Value:      enUS,
+			},
+			rule.Criterion{
+				Comparator: rule.ComparatorGT,
+				Key:        rule.UserSubscription,
+				Value:      0,
+			},
+		},
+		[]rule.Bucket{
+			{
+				Name: "someBucketName",
+				Parameters: rule.Parameters{
+					paramKey: true,
+				},
+			},
+		},
+		nil,
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ruleRepo.Create(override)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router.ServeHTTP(rec, req)
+
+	t.Log(string(rec.Body.Bytes()))
+
+	if have, want := rec.Code, http.StatusOK; have != want {
+		t.Fatalf("have %v, want %v", have, want)
+	}
+
+	uc, err := userRepo.GetLatest(baseID, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := rule.Parameters{
+		paramKey: true,
+	}
+
+	if have := uc.rendered; !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func injectAuth(clientID, userID string) endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, request interface{}) (interface{}, error) {
+			ctx = context.WithValue(ctx, client.ContextKeyClientID, clientID)
+			ctx = context.WithValue(ctx, auth.ContextKeyUserID, userID)
+
+			return next(ctx, request)
+		}
+	}
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -33,12 +33,13 @@ var (
 
 // Rule errors.
 var (
-	ErrInvalidRule        = errors.New("invalid rule")
-	ErrInvalidTypeToMatch = errors.New("invalid type")
-	ErrNoRuleForID        = errors.New("no rules for this ID")
-	ErrNoRuleWithName     = errors.New("no rule with name")
-	ErrCriterionNotMatch  = errors.New("no criterion match")
-	ErrRuleNotInRollout   = errors.New("not in rollout")
+	ErrInvalidRule               = errors.New("invalid rule")
+	ErrInvalidTypeToMatch        = errors.New("invalid type")
+	ErrNoRuleForID               = errors.New("no rules for this ID")
+	ErrNoRuleWithName            = errors.New("no rule with name")
+	ErrCriterionNotMatch         = errors.New("no criterion match")
+	ErrRuleNotInRollout          = errors.New("not in rollout")
+	ErrParsingInvalidLanguageTag = errors.New("invalid language to parse")
 )
 
 // Cause is a wraper over github.com/pkg/errors.Cause.

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -34,10 +34,10 @@ var (
 // Rule errors.
 var (
 	ErrInvalidRule        = errors.New("invalid rule")
-	ErrInvalidTypeToMatch = errors.New("invalid input type")
+	ErrInvalidTypeToMatch = errors.New("invalid type")
 	ErrNoRuleForID        = errors.New("no rules for this ID")
 	ErrNoRuleWithName     = errors.New("no rule with name")
-	ErrRuleNoMatch        = errors.New("no match")
+	ErrCriterionNotMatch  = errors.New("no criterion match")
 	ErrRuleNotInRollout   = errors.New("not in rollout")
 )
 

--- a/pkg/rule/criteria.go
+++ b/pkg/rule/criteria.go
@@ -1,94 +1,286 @@
 package rule
 
 import (
-	"reflect"
+	"encoding/json"
+
+	"golang.org/x/text/language"
 
 	"github.com/lifesum/configsum/pkg/errors"
 )
 
+// Comparators.
 const (
-	comparatorGT comparator = iota
+	ComparatorGT Comparator = iota
+	ComparatorEQ
+	ComparatorNQ
+	ComparatorIN
 )
 
-type comparator int8
+// Comparator defines the type of comparison for a Criterion.
+type Comparator int8
 
-// Criteria defines if a rule will match on the given context data.
-type Criteria struct {
-	User   *CriteriaUser
-	Locale *MatcherString
-}
-
-// CriteriaUser holds all relevant matchers concerning a user.
-type CriteriaUser struct {
-	Age          *MatcherInt
-	ID           *MatcherStringList
-	Subscription *MatcherInt
-}
-
-// MatcherBool defines methods for matching a rule on bool type
-type MatcherBool struct {
-	value bool
-}
-
-func (m MatcherBool) match(input interface{}) (bool, error) {
-	t, ok := input.(bool)
-	if !ok {
-		return false, errors.Wrapf(errors.ErrInvalidTypeToMatch, "missmatch %s != bool", reflect.TypeOf(input).Kind())
-	}
-
-	return t == m.value, nil
-}
-
-// MatcherInt defines methods for matching a rule on int type
-type MatcherInt struct {
-	Comparator comparator
-	Value      int
-}
-
-func (m MatcherInt) match(input interface{}) (bool, error) {
-	t, ok := input.(int)
-	if !ok {
-		return false, errors.Wrapf(errors.ErrInvalidTypeToMatch, "missmatch %s != int", reflect.TypeOf(input).Kind())
-	}
-
-	switch m.Comparator {
-	case comparatorGT:
-		return t > m.Value, nil
+func (c Comparator) String() string {
+	switch c {
+	case ComparatorEQ:
+		return "ComparatorEQ"
+	case ComparatorNQ:
+		return "ComparatorNQ"
+	case ComparatorGT:
+		return "ComparatorGT"
+	case ComparatorIN:
+		return "ComparatorIN"
 	default:
-		return false, nil
+		return "unknown comparator"
 	}
 }
 
-// MatcherString defines methods for matching a rule on string type
-type MatcherString string
+// App context keys.
+const (
+	AppVersion CriterionKey = iota + 1
+)
 
-func (m MatcherString) match(input interface{}) (bool, error) {
-	t, ok := input.(string)
-	if !ok {
-		return false, errors.Wrapf(errors.ErrInvalidTypeToMatch, "missmatch %s != string", reflect.TypeOf(input).Kind())
+// Device context keys.
+const (
+	DeviceLocationLocale CriterionKey = iota + 101
+	DeviceLocationOffset
+	DeviceOSPlatform
+	DeviceOSVersion
+)
+
+// Metadata context keys.
+const (
+	MetadataBool CriterionKey = iota + 201
+	MetadataNumber
+	MetadataString
+)
+
+// User context keys.
+const (
+	UserAge CriterionKey = iota + 301
+	UserRegistered
+	UserID
+	UserSubscription
+)
+
+// CriterionKey is the set of possible input to match on.
+type CriterionKey int
+
+func (k CriterionKey) String() string {
+	switch k {
+	case AppVersion:
+		return "AppVersion"
+	case UserID:
+		return "UserID"
+	case UserSubscription:
+		return "UserSubscription"
+	default:
+		return "unknown"
 	}
-
-	if t == string(m) {
-		return true, nil
-	}
-
-	return false, nil
 }
 
-// MatcherStringList defines methods for matching a rule on string list type
-type MatcherStringList []string
+// Criteria is a collection of Criterion.
+type Criteria []Criterion
 
-func (m MatcherStringList) match(input interface{}) (bool, error) {
-	t, ok := input.(string)
-	if !ok {
-		return false, errors.Wrapf(errors.ErrInvalidTypeToMatch, "missmatch %s != string", reflect.TypeOf(input).Kind())
-	}
+// Criterion is a single decision which can be evaluated to decide if a Rule
+// should be applied.
+type Criterion struct {
+	Comparator Comparator
+	Key        CriterionKey
+	Value      interface{}
+	Path       string
+}
 
-	for _, v := range m {
-		if t == v {
-			return true, nil
+// MarshalJSON to satisfy json.Marshaler.
+func (c Criterion) MarshalJSON() ([]byte, error) {
+	var value interface{}
+
+	switch c.Key {
+	case DeviceLocationLocale:
+		t, ok := c.Value.(language.Tag)
+		if !ok {
+			return nil, errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value not a language.Tag", c.Key)
 		}
+
+		value = t.String()
+	case UserSubscription:
+		t, ok := c.Value.(int)
+		if !ok {
+			return nil, errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value noat an int", c.Key)
+		}
+
+		value = t
+	case UserID:
+		t, ok := c.Value.([]string)
+		if !ok {
+			return nil, errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value not a string slice", c.Key)
+		}
+
+		value = t
+	default:
+		return nil, errors.Errorf("marshaling for '%s' not supported", c.Key)
 	}
 
-	return false, nil
+	return json.Marshal(struct {
+		Comparator Comparator   `json:"comparator"`
+		Key        CriterionKey `json:"key"`
+		Value      interface{}  `json:"value"`
+		Path       string       `json:"path"`
+	}{
+		Comparator: c.Comparator,
+		Key:        c.Key,
+		Value:      value,
+		Path:       c.Path,
+	})
+}
+
+// UnmarshalJSON to satisfy json.Unmarshaler.
+func (c *Criterion) UnmarshalJSON(raw []byte) error {
+	v := struct {
+		Comparator Comparator   `json:"comparator"`
+		Key        CriterionKey `json:"key"`
+		Value      interface{}  `json:"value"`
+		Path       string       `json:"path"`
+	}{}
+
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return err
+	}
+
+	c.Comparator = v.Comparator
+	c.Key = v.Key
+	c.Path = v.Path
+
+	switch c.Key {
+	case DeviceLocationLocale:
+		s, ok := v.Value.(string)
+		if !ok {
+			return errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value not a string", c.Key)
+		}
+
+		t, err := language.Parse(s)
+		if err != nil {
+			// TODO(xla): Wrap in proper marshal error.
+			return err
+		}
+
+		c.Value = t
+	case UserSubscription:
+		s, ok := v.Value.(float64)
+		if !ok {
+			return errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value not an int", c.Key)
+		}
+
+		c.Value = int(s)
+	case UserID:
+		s, ok := constructSlice(v.Value)
+		if !ok {
+			return errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value not a string slice", c.Key)
+		}
+
+		c.Value = s
+	default:
+		return errors.Errorf("unmarshaling for '%s' not supported", c.Key)
+	}
+
+	return nil
+}
+
+func (c Criterion) match(ctx Context) error {
+	switch c.Key {
+	case DeviceLocationLocale:
+		expected, ok := c.Value.(language.Tag)
+		if !ok {
+			return errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value not a language.Tag", c.Key)
+		}
+
+		return matchLocationLocale(c.Comparator, expected, ctx.Locale.Locale)
+	case UserSubscription:
+		expected, ok := c.Value.(int)
+		if !ok {
+			return errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value not an int", c.Key)
+		}
+		return matchUserSubscription(c.Comparator, expected, ctx.User.Subscription)
+	case UserID:
+		expected, ok := constructSlice(c.Value)
+		if !ok {
+			return errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value not a string slice", c.Key)
+		}
+
+		return matchUserID(c.Comparator, expected, ctx.User.ID)
+	default:
+		errors.Errorf("unsupported Key '%d'", c.Key)
+	}
+
+	return nil
+}
+
+func matchUserID(comparator Comparator, expected []string, input string) error {
+	switch comparator {
+	case ComparatorIN:
+		for _, id := range expected {
+			if id == input {
+				return nil
+			}
+		}
+	default:
+		return errors.Errorf("comparator '%s' not supported", comparator)
+	}
+
+	return errors.Wrap(errors.ErrCriterionNotMatch, "id cannot be found in the id list")
+}
+
+func matchUserSubscription(comparator Comparator, expected, input int) error {
+	switch comparator {
+	case ComparatorGT:
+		if input <= expected {
+			return errors.Wrap(errors.ErrCriterionNotMatch, "input value smaller or equal than criterion value")
+		}
+	default:
+		return errors.Errorf("comparator '%s' not supported", comparator)
+	}
+
+	return nil
+}
+
+func matchLocationLocale(comparator Comparator, expected, input language.Tag) error {
+	var (
+		er, _ = expected.Region()
+		ir, _ = input.Region()
+		ok    = er.Contains(ir)
+	)
+
+	switch comparator {
+	case ComparatorEQ:
+		if !ok {
+			return errors.Wrap(errors.ErrCriterionNotMatch, "input region not part of expected region")
+		}
+	case ComparatorNQ:
+		if ok {
+			return errors.Wrap(errors.ErrCriterionNotMatch, "input region is part of expected region")
+		}
+	default:
+		return errors.Errorf("comparator '%s' not supproted", comparator)
+	}
+
+	return nil
+}
+
+func constructSlice(input interface{}) ([]string, bool) {
+	r := []string{}
+	switch v := input.(type) {
+	case []string:
+		for _, s := range v {
+			r = append(r, s)
+		}
+
+		return r, true
+	case []interface{}:
+		for _, s := range v {
+			r = append(r, s.(string))
+		}
+
+		return r, true
+	default:
+		return nil, false
+	}
 }

--- a/pkg/rule/criteria.go
+++ b/pkg/rule/criteria.go
@@ -159,8 +159,7 @@ func (c *Criterion) UnmarshalJSON(raw []byte) error {
 
 		t, err := language.Parse(s)
 		if err != nil {
-			// TODO(xla): Wrap in proper marshal error.
-			return err
+			return errors.Wrapf(errors.ErrParsingInvalidLanguageTag, "%s: language tag invalid", s)
 		}
 
 		c.Value = t

--- a/pkg/rule/criteria_test.go
+++ b/pkg/rule/criteria_test.go
@@ -1,75 +1,66 @@
 package rule
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 
-	"github.com/lifesum/configsum/pkg/generate"
+	"golang.org/x/text/language"
 )
 
-func TestMatcherListString(t *testing.T) {
+func TestCriterionDeviceLocationLocaleMarshal(t *testing.T) {
 	var (
-		input    = generate.RandomString(24)
-		goodVals = []string{
-			input,
-			generate.RandomString(24),
-			generate.RandomString(24),
-		}
-		badVals = []string{
-			generate.RandomString(24),
-			generate.RandomString(24),
-			generate.RandomString(24),
+		tag  = language.MustParse("en-US")
+		want = Criterion{
+			Comparator: ComparatorEQ,
+			Key:        DeviceLocationLocale,
+			Value:      tag,
+			Path:       "",
 		}
 	)
 
-	m := MatcherStringList(goodVals)
-
-	ok, err := m.match(input)
+	raw, err := json.Marshal(&want)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !ok {
-		t.Errorf("expect input to match")
-	}
+	var have Criterion
 
-	m = MatcherStringList(badVals)
-
-	ok, err = m.match(input)
+	err = json.Unmarshal(raw, &have)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if ok {
-		t.Errorf("expect input not to match")
+	if !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
 	}
 }
 
-func TestMatcherString(t *testing.T) {
+func TestCriterionUserSubscriptionMarshal(t *testing.T) {
 	var (
-		input   = generate.RandomString(24)
-		goodVal = input
-		badVal  = generate.RandomString(24)
+		want = Criterion{
+			Comparator: ComparatorEQ,
+			Key:        UserSubscription,
+			Value:      0,
+			Path:       "",
+		}
 	)
 
-	m := MatcherString(goodVal)
-
-	ok, err := m.match(input)
+	raw, err := json.Marshal(&want)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !ok {
-		t.Error("expect input to match")
-	}
+	var have Criterion
 
-	m = MatcherString(badVal)
-
-	ok, err = m.match(input)
+	err = json.Unmarshal(raw, &have)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if ok {
-		t.Error("expect input not to match")
+	if !reflect.DeepEqual(have, want) {
+		t.Log(reflect.TypeOf(want.Value))
+		t.Log(reflect.TypeOf(have.Value))
+		t.Errorf("have %v, want %v", have, want)
 	}
 }

--- a/pkg/rule/endpoint.go
+++ b/pkg/rule/endpoint.go
@@ -116,6 +116,47 @@ func (r *responseBucket) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
+// // ResponseCriterion is used to represent a criterion on the wire.
+// type responseCriterion struct {
+// 	criterion Criterion
+// }
+
+// func (r *responseCriterion) MarshalJSON() ([]byte, error) {
+// 	return json.Marshal(struct {
+// 		Comparator Comparator   `json:"comparator"`
+// 		Key        CriterionKey `json:"key"`
+// 		Value      interface{}  `json:"value"`
+// 		Path       string       `json:"path"`
+// 	}{
+// 		Comparator: r.criterion.Comparator,
+// 		Key:        r.criterion.Key,
+// 		Value:      r.criterion.Value,
+// 		Path:       r.criterion.Path,
+// 	})
+// }
+
+// func (r *responseCriterion) UnmarsealJSON(raw []byte) error {
+// 	v := struct {
+// 		Comparator Comparator   `json:"comparator"`
+// 		Key        CriterionKey `json:"key"`
+// 		Value      interface{}  `json:"value"`
+// 		Path       string       `json:"path"`
+// 	}{}
+
+// 	if err := json.Unmarshal(raw, &v); err != nil {
+// 		return err
+// 	}
+
+// 	r.criterion = Criterion{
+// 		Comparator: v.Comparator,
+// 		Key:        v.Key,
+// 		Value:      v.Value,
+// 		Path:       v.Path,
+// 	}
+
+// 	return nil
+// }
+
 // ResponseParameter used to represent a parameter on the wire.
 type ResponseParameter struct {
 	Name  string      `json:"name"`
@@ -163,116 +204,6 @@ func (r ResponseParameters) Swap(i, j int) {
 	r[i], r[j] = r[j], r[i]
 }
 
-type responseCriteria struct {
-	criteria *Criteria
-}
-
-func (r *responseCriteria) MarshalJSON() ([]byte, error) {
-	var (
-		locale string
-		u      *responseCriteriaUser
-	)
-
-	if r.criteria.Locale != nil {
-		locale = string(*r.criteria.Locale)
-	}
-
-	if r.criteria.User != nil {
-		u = &responseCriteriaUser{user: r.criteria.User}
-	}
-
-	return json.Marshal(struct {
-		Locale string                `json:"locale,omitempty"`
-		User   *responseCriteriaUser `json:"user,omitempty"`
-	}{
-		Locale: locale,
-		User:   u,
-	})
-}
-
-func (r *responseCriteria) UnmarshalJSON(raw []byte) error {
-	if string(raw) == "" || string(raw) == "{}" {
-		return nil
-	}
-
-	v := struct {
-		Locale string                `json:"locale,omitempty"`
-		User   *responseCriteriaUser `json:"user,omitempty"`
-	}{}
-
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return err
-	}
-
-	r.criteria = &Criteria{}
-
-	if v.Locale != "" {
-		locale := MatcherString(v.Locale)
-
-		r.criteria.Locale = &locale
-	}
-
-	if v.User != nil && v.User.user != nil {
-		r.criteria.User = v.User.user
-	}
-
-	return nil
-}
-
-type responseCriteriaUser struct {
-	user *CriteriaUser
-}
-
-func (r *responseCriteriaUser) MarshalJSON() ([]byte, error) {
-	var (
-		is           []string
-		subscription *MatcherInt
-	)
-
-	if r.user.ID != nil {
-		is = []string(*r.user.ID)
-	}
-
-	if r.user.Subscription != nil {
-		subscription = r.user.Subscription
-	}
-
-	return json.Marshal(struct {
-		ID           []string    `json:"id,omitempty"`
-		Subscription *MatcherInt `json:"subscription,omitempty"`
-	}{
-		ID:           is,
-		Subscription: subscription,
-	})
-}
-
-func (r *responseCriteriaUser) UnmarshalJSON(raw []byte) error {
-	if string(raw) == "" || string(raw) == "{}" {
-		return nil
-	}
-
-	v := struct {
-		ID           *MatcherStringList `json:"id"`
-		Subscription *MatcherInt        `json:"subscription"`
-	}{}
-
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return err
-	}
-
-	r.user = &CriteriaUser{}
-
-	if v.ID != nil {
-		r.user.ID = v.ID
-	}
-
-	if v.Subscription != nil {
-		r.user.Subscription = v.Subscription
-	}
-
-	return nil
-}
-
 type responseRule struct {
 	rule Rule
 }
@@ -284,35 +215,29 @@ func (r *responseRule) MarshalJSON() ([]byte, error) {
 		bs = append(bs, responseBucket{bucket: b})
 	}
 
-	var c *responseCriteria
-
-	if r.rule.criteria != nil {
-		c = &responseCriteria{criteria: r.rule.criteria}
-	}
-
 	return json.Marshal(struct {
-		Active      bool              `json:"active"`
-		ActivatedAt time.Time         `json:"activated_at"`
-		Buckets     []responseBucket  `json:"buckets"`
-		ConfigID    string            `json:"config_id"`
-		CreatedAt   string            `json:"created_at"`
-		Criteria    *responseCriteria `json:"criteria,omitempty"`
-		Description string            `json:"description"`
-		Deleted     bool              `json:"deleted"`
-		EndTime     time.Time         `json:"end_time"`
-		ID          string            `json:"id"`
-		Kind        Kind              `json:"kind"`
-		Name        string            `json:"name"`
-		Rollout     uint8             `json:"rollout"`
-		StartTime   time.Time         `json:"start_time"`
-		UpdatedAt   time.Time         `json:"updated_at"`
+		Active      bool             `json:"active"`
+		ActivatedAt time.Time        `json:"activated_at"`
+		Buckets     []responseBucket `json:"buckets"`
+		ConfigID    string           `json:"config_id"`
+		CreatedAt   string           `json:"created_at"`
+		Criteria    Criteria         `json:"criteria,omitempty"`
+		Description string           `json:"description"`
+		Deleted     bool             `json:"deleted"`
+		EndTime     time.Time        `json:"end_time"`
+		ID          string           `json:"id"`
+		Kind        Kind             `json:"kind"`
+		Name        string           `json:"name"`
+		Rollout     uint8            `json:"rollout"`
+		StartTime   time.Time        `json:"start_time"`
+		UpdatedAt   time.Time        `json:"updated_at"`
 	}{
 		Active:      r.rule.active,
 		ActivatedAt: r.rule.activatedAt,
 		Buckets:     bs,
 		ConfigID:    r.rule.configID,
 		CreatedAt:   r.rule.createdAt.Format(time.RFC3339Nano),
-		Criteria:    c,
+		Criteria:    r.rule.criteria,
 		Description: r.rule.description,
 		Deleted:     r.rule.deleted,
 		EndTime:     r.rule.endTime,
@@ -327,21 +252,21 @@ func (r *responseRule) MarshalJSON() ([]byte, error) {
 
 func (r *responseRule) UnmarshalJSON(raw []byte) error {
 	v := struct {
-		Active      bool              `json:"active"`
-		ActivatedAt time.Time         `json:"activated_at"`
-		Buckets     []responseBucket  `json:"buckets"`
-		ConfigID    string            `json:"config_id"`
-		CreatedAt   string            `json:"created_at"`
-		Criteria    *responseCriteria `json:"criteria,omitempty"`
-		Description string            `json:"description"`
-		Deleted     bool              `json:"deleted"`
-		EndTime     time.Time         `json:"end_time"`
-		ID          string            `json:"id"`
-		Kind        Kind              `json:"kind"`
-		Name        string            `json:"name"`
-		Rollout     uint8             `json:"rollout"`
-		StartTime   time.Time         `json:"start_time"`
-		UpdatedAt   time.Time         `json:"updated_at"`
+		Active      bool             `json:"active"`
+		ActivatedAt time.Time        `json:"activated_at"`
+		Buckets     []responseBucket `json:"buckets"`
+		ConfigID    string           `json:"config_id"`
+		CreatedAt   string           `json:"created_at"`
+		Criteria    Criteria         `json:"criteria,omitempty"`
+		Description string           `json:"description"`
+		Deleted     bool             `json:"deleted"`
+		EndTime     time.Time        `json:"end_time"`
+		ID          string           `json:"id"`
+		Kind        Kind             `json:"kind"`
+		Name        string           `json:"name"`
+		Rollout     uint8            `json:"rollout"`
+		StartTime   time.Time        `json:"start_time"`
+		UpdatedAt   time.Time        `json:"updated_at"`
 	}{}
 
 	if err := json.Unmarshal(raw, &v); err != nil {
@@ -359,7 +284,7 @@ func (r *responseRule) UnmarshalJSON(raw []byte) error {
 		activatedAt: v.ActivatedAt,
 		buckets:     bs,
 		configID:    v.ConfigID,
-		criteria:    v.Criteria.criteria,
+		criteria:    v.Criteria,
 		description: v.Description,
 		deleted:     v.Deleted,
 		endTime:     v.EndTime,

--- a/pkg/rule/endpoint.go
+++ b/pkg/rule/endpoint.go
@@ -116,47 +116,6 @@ func (r *responseBucket) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
-// // ResponseCriterion is used to represent a criterion on the wire.
-// type responseCriterion struct {
-// 	criterion Criterion
-// }
-
-// func (r *responseCriterion) MarshalJSON() ([]byte, error) {
-// 	return json.Marshal(struct {
-// 		Comparator Comparator   `json:"comparator"`
-// 		Key        CriterionKey `json:"key"`
-// 		Value      interface{}  `json:"value"`
-// 		Path       string       `json:"path"`
-// 	}{
-// 		Comparator: r.criterion.Comparator,
-// 		Key:        r.criterion.Key,
-// 		Value:      r.criterion.Value,
-// 		Path:       r.criterion.Path,
-// 	})
-// }
-
-// func (r *responseCriterion) UnmarsealJSON(raw []byte) error {
-// 	v := struct {
-// 		Comparator Comparator   `json:"comparator"`
-// 		Key        CriterionKey `json:"key"`
-// 		Value      interface{}  `json:"value"`
-// 		Path       string       `json:"path"`
-// 	}{}
-
-// 	if err := json.Unmarshal(raw, &v); err != nil {
-// 		return err
-// 	}
-
-// 	r.criterion = Criterion{
-// 		Comparator: v.Comparator,
-// 		Key:        v.Key,
-// 		Value:      v.Value,
-// 		Path:       v.Path,
-// 	}
-
-// 	return nil
-// }
-
 // ResponseParameter used to represent a parameter on the wire.
 type ResponseParameter struct {
 	Name  string      `json:"name"`

--- a/pkg/rule/postgres.go
+++ b/pkg/rule/postgres.go
@@ -311,12 +311,12 @@ func (r *PGRepo) GetByID(id string) (Rule, error) {
 
 	// TODO(xla): If the the value in the column is NULL criteria will be non
 	// nil if we don't have this extra check in place.
-	var criteria *Criteria
+	var criteria Criteria
 
 	if len(raw.Criteria) > 0 && string(raw.Criteria) != "null" {
-		criteria = &Criteria{}
+		criteria = Criteria{}
 
-		if err := json.Unmarshal(raw.Criteria, criteria); err != nil {
+		if err := json.Unmarshal(raw.Criteria, &criteria); err != nil {
 			return Rule{}, errors.Wrap(err, "unmarshal criteria")
 		}
 	}
@@ -559,7 +559,7 @@ func buildList(rows *sqlx.Rows) ([]Rule, error) {
 			buckets:     buckets,
 			configID:    raw.ConfigID,
 			createdAt:   raw.CreatedAt,
-			criteria:    &criteria,
+			criteria:    criteria,
 			description: raw.Description,
 			endTime:     endTime,
 			kind:        raw.Kind,

--- a/pkg/rule/transport_test.go
+++ b/pkg/rule/transport_test.go
@@ -51,7 +51,6 @@ func TestRuleActivate(t *testing.T) {
 			},
 		},
 		nil,
-		randIntGenTest,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -115,7 +114,6 @@ func TestRuleDeactivate(t *testing.T) {
 			},
 		},
 		nil,
-		randIntGenTest,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -160,7 +158,23 @@ func TestRuleGet(t *testing.T) {
 		req      = httptest.NewRequest("GET", target, nil)
 		rec      = httptest.NewRecorder()
 		r        = MakeHandler(svc)
-		locale   = MatcherString("en_GB")
+		ids      = []string{
+			generate.RandomString(12),
+			generate.RandomString(12),
+			generate.RandomString(12),
+		}
+		criteria = Criteria{
+			Criterion{
+				Comparator: ComparatorGT,
+				Key:        UserSubscription,
+				Value:      1,
+			},
+			Criterion{
+				Comparator: ComparatorIN,
+				Key:        UserID,
+				Value:      ids,
+			},
+		}
 	)
 
 	rule, err := New(
@@ -170,20 +184,7 @@ func TestRuleGet(t *testing.T) {
 		"Overrides funky feature for all staff memebers",
 		KindOverride,
 		true,
-		&Criteria{
-			Locale: &locale,
-			User: &CriteriaUser{
-				ID: &MatcherStringList{
-					generate.RandomString(12),
-					generate.RandomString(12),
-					generate.RandomString(12),
-				},
-				Subscription: &MatcherInt{
-					Comparator: comparatorGT,
-					Value:      1,
-				},
-			},
-		},
+		criteria,
 		[]Bucket{
 			{
 				Name: "default",
@@ -193,7 +194,6 @@ func TestRuleGet(t *testing.T) {
 			},
 		},
 		nil,
-		randIntGenTest,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -226,14 +226,6 @@ func TestRuleGet(t *testing.T) {
 	}
 
 	if have, want := resp.rule.configID, created.configID; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-
-	if have, want := resp.rule.criteria.Locale, created.criteria.Locale; !reflect.DeepEqual(have, want) {
-		t.Errorf("have %v, want %v", have, want)
-	}
-
-	if have, want := resp.rule.criteria.User, created.criteria.User; !reflect.DeepEqual(have, want) {
 		t.Errorf("have %v, want %v", have, want)
 	}
 
@@ -311,7 +303,6 @@ func TestRuleList(t *testing.T) {
 				},
 			},
 			nil,
-			randIntGenTest,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -371,7 +362,6 @@ func TestRuleUpdateRollout(t *testing.T) {
 			},
 		},
 		nil,
-		randIntGenTest,
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The old rule criteria structure was hard to reason about giving its nested nature. Therefore we decided to replace it with a structure that allows adding as many types of criteria as needed.
With this we replace the hardcoded fix we had in place at the service level.

* inject random function generator in user service for diceroll testing
* update tests and make them run in parallel
* add safer way to marshal/unmarshal criteria (thanks to xla)