### PR TITLE
Date comparison rule

### DIFF
--- a/pkg/rule/criteria.go
+++ b/pkg/rule/criteria.go
@@ -62,6 +62,11 @@ const (
 	UserSubscription
 )
 
+// Date comparison key
+const (
+	ValidDate CriterionKey = iota + 401
+)
+
 // CriterionKey is the set of possible input to match on.
 type CriterionKey int
 
@@ -113,6 +118,14 @@ func (c Criterion) MarshalJSON() ([]byte, error) {
 		t, ok := c.Value.([]string)
 		if !ok {
 			return nil, errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value not a string slice", c.Key)
+		}
+
+		value = t
+
+	case ValidDate:
+		t, ok := c.Value.(int)
+		if !ok {
+			return nil, errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value noat an int", c.Key)
 		}
 
 		value = t
@@ -177,6 +190,14 @@ func (c *Criterion) UnmarshalJSON(raw []byte) error {
 		}
 
 		c.Value = s
+
+	case ValidDate:
+		s, ok := v.Value.(float64)
+		if !ok {
+			return errors.Wrapf(errors.ErrInvalidTypeToMatch, "%s: value not an int", c.Key)
+		}
+
+		c.Value = int(s)
 	default:
 		return errors.Errorf("unmarshaling for '%s' not supported", c.Key)
 	}

--- a/pkg/rule/criteria_test.go
+++ b/pkg/rule/criteria_test.go
@@ -64,3 +64,32 @@ func TestCriterionUserSubscriptionMarshal(t *testing.T) {
 		t.Errorf("have %v, want %v", have, want)
 	}
 }
+
+func TestValidDateCriteriaMarshal(t *testing.T) {
+	var (
+		want = Criterion{
+			Comparator: ComparatorEQ,
+			Key:        ValidDate,
+			Value:      0,
+			Path:       "",
+		}
+	)
+
+	raw, err := json.Marshal(&want)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var have Criterion
+
+	err = json.Unmarshal(raw, &have)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(have, want) {
+		t.Log(reflect.TypeOf(want.Value))
+		t.Log(reflect.TypeOf(have.Value))
+		t.Errorf("have %v, want %v", have, want)
+	}
+}

--- a/pkg/rule/postgres_test.go
+++ b/pkg/rule/postgres_test.go
@@ -73,6 +73,12 @@ func TestPostgresRepoCreateRollout(t *testing.T) {
 	testRepoCreateRollout(t, preparePGRepo)
 }
 
+func TestRepoNoCriteria(t *testing.T) {
+	t.Parallel()
+
+	testRepoNoCriteria(t, preparePGRepo)
+}
+
 func preparePGRepo(t *testing.T) Repo {
 	db, err := sqlx.Connect("postgres", pgURI)
 	if err != nil {


### PR DESCRIPTION
Extend criteria to handle marshaling for ValidDate key.

As the ListActive query fetches all rules that have a valid the current date there is no need to match on this criteria. We do need however to handle the marshal/unmarshal step.

* update tests